### PR TITLE
Add functionality to move tool

### DIFF
--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -131,5 +131,6 @@ class WaystoneWarps: JavaPlugin() {
         server.pluginManager.registerEvents(WaystoneDestructionListener(), this)
         server.pluginManager.registerEvents(PlayerMovementListener(), this)
         server.pluginManager.registerEvents(MoveToolListener(), this)
+        server.pluginManager.registerEvents(ToolRemovalListener(), this)
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -12,6 +12,7 @@ import dev.mizarc.waystonewarps.application.actions.discovery.GetWarpPlayerAcces
 import dev.mizarc.waystonewarps.application.actions.world.RefreshAllStructures
 import dev.mizarc.waystonewarps.application.actions.management.UpdateWarpIcon
 import dev.mizarc.waystonewarps.application.actions.management.UpdateWarpName
+import dev.mizarc.waystonewarps.application.actions.world.MoveWarp
 import dev.mizarc.waystonewarps.application.services.*
 import dev.mizarc.waystonewarps.application.services.scheduling.SchedulerService
 import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
@@ -115,6 +116,7 @@ class WaystoneWarps: JavaPlugin() {
             single { TeleportPlayer(teleportationService, playerAttributeService)}
             single { LogPlayerMovement(movementMonitorService) }
             single { DiscoverWarp(discoveryRepository) }
+            single { MoveWarp(warpRepository, structureBuilderService) }
         }
 
         startKoin { modules(actions) }
@@ -128,5 +130,6 @@ class WaystoneWarps: JavaPlugin() {
         server.pluginManager.registerEvents(WaystoneInteractListener(), this)
         server.pluginManager.registerEvents(WaystoneDestructionListener(), this)
         server.pluginManager.registerEvents(PlayerMovementListener(), this)
+        server.pluginManager.registerEvents(MoveToolListener(), this)
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -97,7 +97,7 @@ class WaystoneWarps: JavaPlugin() {
         movementMonitorService = MovementMonitorServiceBukkit()
         configService = ConfigServiceBukkit(this.config)
         playerAttributeService = PlayerAttributeServiceVault(configService, metadata)
-        structureBuilderService = StructureBuilderServiceBukkit()
+        structureBuilderService = StructureBuilderServiceBukkit(this)
         scheduler = SchedulerServiceBukkit(this)
         teleportationService = TeleportationServiceBukkit(playerAttributeService, configService,
             movementMonitorService, scheduler, economy)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/BreakWarpBlock.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/BreakWarpBlock.kt
@@ -28,7 +28,7 @@ class BreakWarpBlock(private val warpRepository: WarpRepository,
         for (discovery in discoveries) {
             discoveryRepository.remove(discovery.warpId, discovery.playerId)
         }
-        structureBuilderService.despawnStructure(warp)
+        structureBuilderService.revertStructure(warp)
         return BreakWarpResult.Success(warp)
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/MoveWarp.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/MoveWarp.kt
@@ -1,0 +1,24 @@
+package dev.mizarc.waystonewarps.application.actions.world
+
+import dev.mizarc.waystonewarps.application.results.MoveWarpResult
+import dev.mizarc.waystonewarps.application.services.StructureBuilderService
+import dev.mizarc.waystonewarps.domain.positioning.Position3D
+import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+import java.util.UUID
+
+class MoveWarp(private val warpRepository: WarpRepository,
+               private val structureBuilderService: StructureBuilderService) {
+    fun execute(playerId: UUID, warpId: UUID, position: Position3D): MoveWarpResult {
+        val warp = warpRepository.getById(warpId) ?: return MoveWarpResult.WARP_NOT_FOUND
+
+        if (warp.playerId != playerId) {
+            return MoveWarpResult.NOT_OWNER
+        }
+
+        structureBuilderService.despawnStructure(warp)
+        warp.position = position
+        structureBuilderService.spawnStructure(warp)
+        warpRepository.update(warp)
+        return MoveWarpResult.SUCCESS
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/MoveWarp.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/MoveWarp.kt
@@ -15,7 +15,7 @@ class MoveWarp(private val warpRepository: WarpRepository,
             return MoveWarpResult.NOT_OWNER
         }
 
-        structureBuilderService.despawnStructure(warp)
+        structureBuilderService.destroyStructure(warp)
         warp.position = position
         structureBuilderService.spawnStructure(warp)
         warpRepository.update(warp)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/RefreshAllStructures.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/RefreshAllStructures.kt
@@ -8,7 +8,7 @@ class RefreshAllStructures(private val warpRepository: WarpRepository,
     fun execute() {
         val warps = warpRepository.getAll()
         for (warp in warps) {
-            structureBuilderService.despawnStructure(warp)
+            structureBuilderService.destroyStructure(warp)
             structureBuilderService.spawnStructure(warp)
         }
     }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/results/MoveWarpResult.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/results/MoveWarpResult.kt
@@ -1,0 +1,7 @@
+package dev.mizarc.waystonewarps.application.results
+
+enum class MoveWarpResult {
+    SUCCESS,
+    NOT_OWNER,
+    WARP_NOT_FOUND
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/services/StructureBuilderService.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/services/StructureBuilderService.kt
@@ -12,7 +12,12 @@ interface StructureBuilderService {
     fun spawnStructure(warp: Warp)
 
     /**
+     * Reverts the structure back into its base components
+     */
+    fun revertStructure(warp: Warp)
+
+    /**
      * Destroys the waystone structure in the world.
      */
-    fun despawnStructure(warp: Warp)
+    fun destroyStructure(warp: Warp)
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
@@ -12,19 +12,27 @@ import org.bukkit.World
 import org.bukkit.entity.BlockDisplay
 import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
+import org.bukkit.plugin.Plugin
+import org.bukkit.scheduler.BukkitRunnable
 import org.bukkit.util.Transformation
 import org.joml.AxisAngle4f
 import org.joml.Vector3f
-import java.util.UUID
+import java.util.*
 
-class StructureBuilderServiceBukkit: StructureBuilderService {
+class StructureBuilderServiceBukkit(private val plugin: Plugin): StructureBuilderService {
 
     override fun spawnStructure(warp: Warp) {
         // Replace bottom block with barrier
         val world = Bukkit.getWorld(warp.worldId) ?: return
         val location = warp.position.toLocation(world)
         location.block.type = Material.LODESTONE
-        world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ).type = Material.BARRIER
+
+        // Needs to be a 1 tick delay here because Bukkit is ass and spits out a stupid POI data mismatch error
+        object : BukkitRunnable() {
+            override fun run() {
+                world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ).type = Material.BARRIER
+            }
+        }.runTaskLater(plugin, 1L)
 
         // Generate custom model
         createBlockDisplay(warp.id, warp.position.toLocation(world), Material.SMOOTH_STONE_SLAB,

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
@@ -27,12 +27,12 @@ class StructureBuilderServiceBukkit(private val plugin: Plugin): StructureBuilde
         val location = warp.position.toLocation(world)
         location.block.type = Material.LODESTONE
 
-        // Needs to be a 1 tick delay here because Bukkit is ass and spits out a stupid POI data mismatch error
+        // Needs to be a 2 tick delay here because Bukkit is ass and spits out a stupid POI data mismatch error
         object : BukkitRunnable() {
             override fun run() {
                 world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ).type = Material.BARRIER
             }
-        }.runTaskLater(plugin, 1L)
+        }.runTaskLater(plugin, 2L)
 
         // Generate custom model
         createBlockDisplay(warp.id, warp.position.toLocation(world), Material.SMOOTH_STONE_SLAB,

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
@@ -8,6 +8,7 @@ import net.kyori.adventure.text.TextComponent
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.Material
+import org.bukkit.World
 import org.bukkit.entity.BlockDisplay
 import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
@@ -22,8 +23,8 @@ class StructureBuilderServiceBukkit: StructureBuilderService {
         // Replace bottom block with barrier
         val world = Bukkit.getWorld(warp.worldId) ?: return
         val location = warp.position.toLocation(world)
-        val bottomBlock = world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ)
-        bottomBlock.type = Material.BARRIER
+        location.block.type = Material.LODESTONE
+        world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ).type = Material.BARRIER
 
         // Generate custom model
         createBlockDisplay(warp.id, warp.position.toLocation(world), Material.SMOOTH_STONE_SLAB,
@@ -40,21 +41,19 @@ class StructureBuilderServiceBukkit: StructureBuilderService {
             0.85f, 0.85f, 0.85f)
     }
 
-    override fun despawnStructure(warp: Warp) {
-        // Change lower block back into smooth stone
+    override fun revertStructure(warp: Warp) {
         val world = Bukkit.getWorld(warp.worldId) ?: return
         val location = warp.position.toLocation(world)
-        val bottomBlock = world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ)
-        bottomBlock.type = Material.SMOOTH_STONE
+        world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ).type = Material.SMOOTH_STONE
+        removeBlockDisplay(warp, world)
+    }
 
-        // Remove connected block display entities
-        val entities: MutableList<Entity> = location.world.entities
-        for (entity in entities) {
-            val customName = entity.customName() ?: continue
-            if (customName is TextComponent && customName.content() == warp.id.toString()) {
-                entity.remove()
-            }
-        }
+    override fun destroyStructure(warp: Warp) {
+        val world = Bukkit.getWorld(warp.worldId) ?: return
+        val location = warp.position.toLocation(world)
+        location.block.type = Material.AIR
+        world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ).type = Material.AIR
+        removeBlockDisplay(warp, world)
     }
 
     private fun createBlockDisplay(warpId: UUID, baseLocation: Location, material: Material,
@@ -72,5 +71,15 @@ class StructureBuilderServiceBukkit: StructureBuilderService {
             Vector3f(scaleX, scaleY, scaleZ), AxisAngle4f())
         blockDisplay.transformation = transformation
         blockDisplay.customName(Component.text((warpId.toString())))
+    }
+
+    private fun removeBlockDisplay(warp: Warp, world: World) {
+        val entities: MutableList<Entity> = world.entities
+        for (entity in entities) {
+            val customName = entity.customName() ?: continue
+            if (customName is TextComponent && customName.content() == warp.id.toString()) {
+                entity.remove()
+            }
+        }
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/MoveToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/MoveToolListener.kt
@@ -5,8 +5,6 @@ import dev.mizarc.waystonewarps.application.results.MoveWarpResult
 import dev.mizarc.waystonewarps.infrastructure.mappers.toPosition3D
 import dev.mizarc.waystonewarps.interaction.messaging.PrimaryColourPalette
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.format.TextColor
-import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.event.EventHandler
@@ -22,10 +20,11 @@ class MoveToolListener: Listener, KoinComponent {
 
     @EventHandler
     fun onClaimMoveBlockPlace(event: BlockPlaceEvent) {
-
+        // Check to see if item in hand is the warp mover
         val warpId = event.itemInHand.itemMeta.persistentDataContainer.get(
             NamespacedKey("waystonewarps","warp"), PersistentDataType.STRING) ?: return
 
+        // Check if block above is clear
         val aboveLocation = event.block.location.clone()
         aboveLocation.add(0.0, 1.0, 0.0)
         if (event.block.world.getBlockAt(aboveLocation).type != Material.AIR) {
@@ -36,9 +35,8 @@ class MoveToolListener: Listener, KoinComponent {
             return
         }
 
-        val result = moveWarp.execute(event.player.uniqueId, UUID.fromString(warpId),
-            aboveLocation.toPosition3D())
-
+        // Try to move warp
+        val result = moveWarp.execute(event.player.uniqueId, UUID.fromString(warpId), aboveLocation.toPosition3D())
         when (result) {
             MoveWarpResult.SUCCESS -> {
                 event.player.sendActionBar(

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/MoveToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/MoveToolListener.kt
@@ -1,0 +1,59 @@
+package dev.mizarc.waystonewarps.interaction.listeners
+
+import dev.mizarc.waystonewarps.application.actions.world.MoveWarp
+import dev.mizarc.waystonewarps.application.results.MoveWarpResult
+import dev.mizarc.waystonewarps.infrastructure.mappers.toPosition3D
+import dev.mizarc.waystonewarps.interaction.messaging.PrimaryColourPalette
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextColor
+import org.bukkit.Location
+import org.bukkit.Material
+import org.bukkit.NamespacedKey
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.persistence.PersistentDataType
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.UUID
+
+class MoveToolListener: Listener, KoinComponent {
+    private val moveWarp: MoveWarp by inject()
+
+    @EventHandler
+    fun onClaimMoveBlockPlace(event: BlockPlaceEvent) {
+        event.isCancelled = false
+        val warpId = event.itemInHand.itemMeta.persistentDataContainer.get(
+            NamespacedKey("waystonewarps","warp"), PersistentDataType.STRING) ?: return
+
+        val aboveLocation = event.block.location.clone()
+        aboveLocation.add(0.0, 1.0, 0.0)
+        if (event.block.world.getBlockAt(aboveLocation).type != Material.AIR) {
+            event.player.sendActionBar(
+                Component.text("No space to more warp here!")
+                    .color(PrimaryColourPalette.FAILED.color))
+            return
+        }
+
+        val result = moveWarp.execute(event.player.uniqueId, UUID.fromString(warpId),
+            aboveLocation.toPosition3D())
+
+        when (result) {
+            MoveWarpResult.SUCCESS -> {
+                event.player.sendActionBar(
+                    Component.text("Warp position has been moved")
+                        .color(PrimaryColourPalette.SUCCESS.color))
+            }
+            MoveWarpResult.NOT_OWNER -> {
+                event.player.sendActionBar(
+                    Component.text("You don't own this warp!")
+                        .color(PrimaryColourPalette.FAILED.color))
+            }
+            MoveWarpResult.WARP_NOT_FOUND -> {
+                event.player.sendActionBar(
+                    Component.text("The warp you're trying to move can't be found!")
+                        .color(PrimaryColourPalette.FAILED.color))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/MoveToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/MoveToolListener.kt
@@ -22,7 +22,7 @@ class MoveToolListener: Listener, KoinComponent {
 
     @EventHandler
     fun onClaimMoveBlockPlace(event: BlockPlaceEvent) {
-        event.isCancelled = false
+
         val warpId = event.itemInHand.itemMeta.persistentDataContainer.get(
             NamespacedKey("waystonewarps","warp"), PersistentDataType.STRING) ?: return
 
@@ -30,8 +30,9 @@ class MoveToolListener: Listener, KoinComponent {
         aboveLocation.add(0.0, 1.0, 0.0)
         if (event.block.world.getBlockAt(aboveLocation).type != Material.AIR) {
             event.player.sendActionBar(
-                Component.text("No space to more warp here!")
+                Component.text("No space to move warp here!")
                     .color(PrimaryColourPalette.FAILED.color))
+            event.isCancelled = true
             return
         }
 
@@ -48,11 +49,13 @@ class MoveToolListener: Listener, KoinComponent {
                 event.player.sendActionBar(
                     Component.text("You don't own this warp!")
                         .color(PrimaryColourPalette.FAILED.color))
+                event.isCancelled = true
             }
             MoveWarpResult.WARP_NOT_FOUND -> {
                 event.player.sendActionBar(
                     Component.text("The warp you're trying to move can't be found!")
                         .color(PrimaryColourPalette.FAILED.color))
+                event.isCancelled = true
             }
         }
     }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/ToolRemovalListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/ToolRemovalListener.kt
@@ -1,0 +1,135 @@
+package dev.mizarc.waystonewarps.interaction.listeners
+
+import dev.mizarc.waystonewarps.interaction.utils.getStringMeta
+import org.bukkit.Material
+import org.bukkit.block.data.type.DecoratedPot
+import org.bukkit.entity.ItemFrame
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.PlayerDeathEvent
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.event.inventory.InventoryDragEvent
+import org.bukkit.event.player.PlayerDropItemEvent
+import org.bukkit.event.player.PlayerInteractEntityEvent
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.inventory.ItemStack
+
+class ToolRemovalListener: Listener {
+
+    @EventHandler
+    fun onItemDrop(event: PlayerDropItemEvent) {
+        val itemStack = event.itemDrop.itemStack
+        if (isKeyItem(itemStack)) {
+            event.itemDrop.remove()
+        }
+    }
+
+    @EventHandler
+    fun onMoveToInventory(event: InventoryClickEvent) {
+        // Cancel if item is in bottom
+        if (event.clickedInventory === event.view.bottomInventory) {
+            return
+        }
+
+        // Check if item is trying to be placed in top slot
+        val itemStack = event.cursor
+        if (isKeyItem(itemStack)) {
+            event.isCancelled = true
+        }
+    }
+
+    @EventHandler
+    fun onShiftClick(event: InventoryClickEvent) {
+        // Cancel if event isn't a shift click
+        if (!event.click.isShiftClick) {
+            return
+        }
+
+        // Cancel if inventory is top inventory
+        if (event.clickedInventory === event.view.topInventory) {
+            return
+        }
+
+        // Cancel if no item in slot
+        val itemStack = event.currentItem ?: return
+        if (isKeyItem(itemStack)) {
+            event.isCancelled = true
+        }
+    }
+
+    @EventHandler
+    fun onNumberSwap(event: InventoryClickEvent) {
+        // Cancel if event isn't a shift click
+        if (event.hotbarButton == -1) {
+            return
+        }
+
+        // Cancel if inventory is not top inventory
+        if (event.clickedInventory != event.view.topInventory) {
+            return
+        }
+
+        // Cancel if no item in slot
+        val item = event.whoClicked.inventory.getItem(event.hotbarButton) ?: return
+        if (isKeyItem(item)) {
+            event.isCancelled = true
+        }
+    }
+
+    @EventHandler
+    fun onDragToInventory(event: InventoryDragEvent) {
+        val itemStack = event.oldCursor
+        val otherInv = event.view.topInventory
+        if (isKeyItem(itemStack) && otherInv == event.inventory) {
+            event.isCancelled = true
+        }
+    }
+
+    @EventHandler
+    fun onItemFrameUse(event: PlayerInteractEntityEvent) {
+        if (event.rightClicked !is ItemFrame) {
+            return
+        }
+        val mainHandItem = event.player.inventory.itemInMainHand
+        val offHandItem = event.player.inventory.itemInOffHand
+
+        // Cancel event if main hand has item
+        if (isKeyItem(mainHandItem)) {
+            event.isCancelled = true
+        }
+
+        // Cancel event if offhand has item and main hand is empty
+        if (isKeyItem(offHandItem) && mainHandItem.type == Material.AIR) {
+            event.isCancelled = true
+        }
+    }
+
+    @EventHandler
+    fun onPotUse(event: PlayerInteractEvent) {
+        val block = event.clickedBlock ?: return
+        if (block.blockData !is DecoratedPot) {
+            return
+        }
+
+        // Cancel event if main hand has item
+        val item = event.item ?: return
+        if (isKeyItem(item)) {
+            event.isCancelled = true
+        }
+    }
+
+    @EventHandler
+    fun onPlayerDeath(event: PlayerDeathEvent) {
+        val droppedItems = event.drops
+        val itemsToRemove = arrayListOf<ItemStack>()
+        for (droppedItem in droppedItems) {
+            if (isKeyItem(droppedItem)) {
+                itemsToRemove.add(droppedItem)
+            }
+        }
+    }
+
+    private fun isKeyItem(itemStack: ItemStack): Boolean {
+        return itemStack.getStringMeta("warp") != null
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpManagementMenu.kt
@@ -54,7 +54,7 @@ class WarpManagementMenu(private val menuNavigator: MenuNavigator, private val w
             .name("Move Warp")
             .lore("Place the provided item where you want to move the warp")
         val guiMoveItem = GuiItem(moveItem) { givePlayerMoveTool(player) }
-        pane.addItem(guiMoveItem, 7, 0)
+        pane.addItem(guiMoveItem, 8, 0)
 
         gui.show(player)
     }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
@@ -107,13 +107,13 @@ fun ItemStack.flag(vararg flag: ItemFlag): ItemStack {
 fun ItemStack.getBooleanMeta(key: String): String? {
     val meta = itemMeta ?: return null
     return meta.persistentDataContainer.get(
-        NamespacedKey("solidclaims",key), PersistentDataType.STRING)
+        NamespacedKey("waystonewarps",key), PersistentDataType.STRING)
 }
 
 fun ItemStack.setBooleanMeta(key: String, value: Boolean): ItemStack {
     val meta = itemMeta
     meta.persistentDataContainer.set(
-        NamespacedKey("solidclaims",key), PersistentDataType.BOOLEAN, value)
+        NamespacedKey("waystonewarps",key), PersistentDataType.BOOLEAN, value)
     itemMeta = meta
     return this
 }
@@ -121,13 +121,13 @@ fun ItemStack.setBooleanMeta(key: String, value: Boolean): ItemStack {
 fun ItemStack.getStringMeta(key: String): String? {
     val meta = itemMeta ?: return null
     return meta.persistentDataContainer.get(
-        NamespacedKey("solidclaims",key), PersistentDataType.STRING)
+        NamespacedKey("waystonewarps",key), PersistentDataType.STRING)
 }
 
 fun ItemStack.setStringMeta(key: String, value: String): ItemStack {
     val meta = itemMeta
     meta.persistentDataContainer.set(
-        NamespacedKey("solidclaims",key), PersistentDataType.STRING, value)
+        NamespacedKey("waystonewarps",key), PersistentDataType.STRING, value)
     itemMeta = meta
     return this
 }


### PR DESCRIPTION
This allows the player to move the move tool so long as the space is not obstructed. The move tool also cannot be removed from the player's inventory by any means. Trying to remove it will either have it deleted or moved back in place.