### PR TITLE
Fix initial plugin start up process

### DIFF
--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -20,7 +20,6 @@ import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
 import dev.mizarc.waystonewarps.domain.playerstate.PlayerStateRepository
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import net.milkbowl.vault.chat.Chat
-import org.bukkit.plugin.RegisteredServiceProvider
 import org.bukkit.plugin.java.JavaPlugin
 import dev.mizarc.waystonewarps.interaction.commands.WarpMenuCommand
 import dev.mizarc.waystonewarps.infrastructure.persistence.discoveries.DiscoveryRepositorySQLite

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -23,19 +23,17 @@ import net.milkbowl.vault.chat.Chat
 import org.bukkit.plugin.RegisteredServiceProvider
 import org.bukkit.plugin.java.JavaPlugin
 import dev.mizarc.waystonewarps.interaction.commands.WarpMenuCommand
-import dev.mizarc.waystonewarps.infrastructure.services.ConfigServiceBukkit
 import dev.mizarc.waystonewarps.infrastructure.persistence.discoveries.DiscoveryRepositorySQLite
 import dev.mizarc.waystonewarps.infrastructure.persistence.playerstate.PlayerStateRepositoryMemory
 import dev.mizarc.waystonewarps.infrastructure.persistence.storage.SQLiteStorage
 import dev.mizarc.waystonewarps.infrastructure.persistence.storage.Storage
 import dev.mizarc.waystonewarps.infrastructure.persistence.warps.WarpRepositorySQLite
-import dev.mizarc.waystonewarps.infrastructure.services.MovementMonitorServiceBukkit
-import dev.mizarc.waystonewarps.infrastructure.services.PlayerAttributeServiceVault
-import dev.mizarc.waystonewarps.infrastructure.services.StructureBuilderServiceBukkit
+import dev.mizarc.waystonewarps.infrastructure.services.*
 import dev.mizarc.waystonewarps.infrastructure.services.teleportation.TeleportationServiceBukkit
 import dev.mizarc.waystonewarps.infrastructure.services.scheduling.SchedulerServiceBukkit
 import dev.mizarc.waystonewarps.interaction.listeners.*
 import net.milkbowl.vault.economy.Economy
+import org.bukkit.Bukkit
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
 
@@ -61,36 +59,38 @@ class WaystoneWarps: JavaPlugin() {
     private lateinit var scheduler: SchedulerService
 
     override fun onEnable() {
-        logger.info(Chat::class.java.toString())
-
-        // Get Vault metadata
-        val chatServiceProvider: RegisteredServiceProvider<Chat> = server.servicesManager
-            .getRegistration(Chat::class.java)!!
-        metadata = chatServiceProvider.provider
-
-        // Get Vault economy
-        val economyServiceProvider: RegisteredServiceProvider<Economy>? = server.servicesManager
-            .getRegistration(Economy::class.java)
-        if (economyServiceProvider != null) {
-            economy = economyServiceProvider.provider
-        }
         // Create plugin folder
         if (!dataFolder.exists()) dataFolder.mkdir()
 
+        // Get storage type
         storage = SQLiteStorage(this)
+
+        // Get command manager
         commandManager = PaperCommandManager(this)
+
+        // Initialise everything else
         saveDefaultConfig()
+        initialiseVaultDependency()
         initialiseRepositories()
         initialiseServices()
         registerDependencies()
         registerCommands()
         registerEvents()
         RefreshAllStructures(warpRepository, structureBuilderService).execute()
+
         logger.info("WaystoneWarps has been Enabled")
     }
 
     override fun onDisable() {
         logger.info("WaystoneWarps has been Disabled")
+    }
+
+    private fun initialiseVaultDependency() {
+        if (Bukkit.getPluginManager().getPlugin("Vault") != null) {
+            server.servicesManager.getRegistration(Chat::class.java)?.let { metadata = it.provider }
+            server.servicesManager.getRegistration(Economy::class.java)?.let {economy = it.provider}
+            logger.info(Chat::class.java.toString())
+        }
     }
 
     private fun initialiseRepositories() {
@@ -102,7 +102,11 @@ class WaystoneWarps: JavaPlugin() {
     private fun initialiseServices() {
         movementMonitorService = MovementMonitorServiceBukkit()
         configService = ConfigServiceBukkit(this, this.config)
-        playerAttributeService = PlayerAttributeServiceVault(configService, metadata)
+        playerAttributeService = if (::metadata.isInitialized) {
+            PlayerAttributeServiceVault(configService, metadata)
+        } else {
+            PlayerAttributeServiceSimple(configService)
+        }
         structureBuilderService = StructureBuilderServiceBukkit(this)
         scheduler = SchedulerServiceBukkit(this)
         teleportationService = TeleportationServiceBukkit(playerAttributeService, configService,

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -63,7 +63,7 @@ class WaystoneWarps: JavaPlugin() {
         if (!dataFolder.exists()) dataFolder.mkdir()
 
         // Get storage type
-        storage = SQLiteStorage(this)
+        storage = SQLiteStorage(this.dataFolder)
 
         // Get command manager
         commandManager = PaperCommandManager(this)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/storage/SQLiteStorage.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/storage/SQLiteStorage.kt
@@ -3,13 +3,13 @@ package dev.mizarc.waystonewarps.infrastructure.persistence.storage
 import co.aikar.idb.Database
 import co.aikar.idb.DatabaseOptions
 import co.aikar.idb.PooledDatabaseOptions
-import org.bukkit.plugin.Plugin
+import java.io.File
 
-class SQLiteStorage(plugin: Plugin): Storage<Database> {
+class SQLiteStorage(dataFolder: File): Storage<Database> {
     override val connection: Database
 
     init {
-        val options = DatabaseOptions.builder().sqlite(plugin.dataFolder.toString() + "/storage.db").build()
+        val options = DatabaseOptions.builder().sqlite("$dataFolder/storage.sqlite").build()
         connection = PooledDatabaseOptions.builder().options(options).createHikariDatabase()
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/storage/SQLiteStorage.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/storage/SQLiteStorage.kt
@@ -9,7 +9,7 @@ class SQLiteStorage(plugin: Plugin): Storage<Database> {
     override val connection: Database
 
     init {
-        val options = DatabaseOptions.builder().sqlite(plugin.dataFolder.toString() + "/claims.db").build()
+        val options = DatabaseOptions.builder().sqlite(plugin.dataFolder.toString() + "/storage.db").build()
         connection = PooledDatabaseOptions.builder().options(options).createHikariDatabase()
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
@@ -8,10 +8,6 @@ import java.io.File
 
 class ConfigServiceBukkit(private val plugin: Plugin, private val configFile: FileConfiguration): ConfigService {
 
-    init {
-        createDefaultConfig()
-    }
-
     override fun getWarpLimit(): Int {
         return configFile.getInt("warp_limit", 3)
     }
@@ -30,12 +26,5 @@ class ConfigServiceBukkit(private val plugin: Plugin, private val configFile: Fi
 
     override fun getTeleportCostAmount(): Double {
         return configFile.getDouble("teleport_cost_amount", 3.0)
-    }
-
-    private fun createDefaultConfig() {
-        val configFile = File(plugin.dataFolder, "config.yml")
-        if (!configFile.exists()) {
-            plugin.saveResource("config.yml", false)
-        }
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
@@ -3,8 +3,14 @@ package dev.mizarc.waystonewarps.infrastructure.services
 import dev.mizarc.waystonewarps.application.services.ConfigService
 import dev.mizarc.waystonewarps.infrastructure.services.teleportation.CostType
 import org.bukkit.configuration.file.FileConfiguration
+import org.bukkit.plugin.Plugin
+import java.io.File
 
-class ConfigServiceBukkit(val configFile: FileConfiguration): ConfigService {
+class ConfigServiceBukkit(private val plugin: Plugin, private val configFile: FileConfiguration): ConfigService {
+
+    init {
+        createDefaultConfig()
+    }
 
     override fun getWarpLimit(): Int {
         return configFile.getInt("warp_limit", 3)
@@ -24,5 +30,12 @@ class ConfigServiceBukkit(val configFile: FileConfiguration): ConfigService {
 
     override fun getTeleportCostAmount(): Double {
         return configFile.getDouble("teleport_cost_amount", 3.0)
+    }
+
+    private fun createDefaultConfig() {
+        val configFile = File(plugin.dataFolder, "config.yml")
+        if (!configFile.exists()) {
+            plugin.saveResource("config.yml", false)
+        }
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/PlayerAttributeServiceSimple.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/PlayerAttributeServiceSimple.kt
@@ -1,0 +1,19 @@
+package dev.mizarc.waystonewarps.infrastructure.services
+
+import dev.mizarc.waystonewarps.application.services.ConfigService
+import dev.mizarc.waystonewarps.application.services.PlayerAttributeService
+import java.util.*
+
+class PlayerAttributeServiceSimple(private val configService: ConfigService): PlayerAttributeService {
+    override fun getWarpLimit(playerId: UUID): Int {
+        return configService.getWarpLimit()
+    }
+
+    override fun getTeleportCost(playerId: UUID): Double {
+        return configService.getTeleportCostAmount()
+    }
+
+    override fun getTeleportTimer(playerId: UUID): Int {
+        return configService.getTeleportTimer()
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,5 @@
+warp_limit: 3
+teleport_timer: 5
+teleport_cost_type: ITEM
+teleport_cost_item: ENDER_PEARL
+teleport_cost: 4


### PR DESCRIPTION
Various issues that needed to be addressed for first run:
- Plugin folder wasn't being created, which immediately errored as soon as anything was to be put in it.
- Vault dependency was required, erroring if it wasn't found.
- Database storage name was incorrect and unclear, renamed to "storage.sqlite" for clarity.