### PR TITLE
Give player invulnerability on teleport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Teleport area has a platform built on teleport to replace missing or hollow blocks to prevent falling.
 - Fluids are prevented from flowing into the teleport zone, as they can fill in the space after the blocks are cleared out.
 - Falling blocks are broken as they fall in to prevent filling the space back in with blocks after the existing blocks are cleared out.
+- Players are now given Resistance 5 on teleport for temporary invulnerability.
 
 ### Changes
 - Text input in menus now defaults to blank.

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/teleportation/TeleportationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/teleportation/TeleportationServiceBukkit.kt
@@ -15,6 +15,8 @@ import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.potion.PotionEffect
+import org.bukkit.potion.PotionEffectType
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -55,6 +57,7 @@ class TeleportationServiceBukkit(private val playerAttributeService: PlayerAttri
         deductCost(player)
         clearArea(warp.position.toLocation(world))
         buildPlatform(warp.position.toLocation(world))
+        player.addPotionEffect(PotionEffect(PotionEffectType.RESISTANCE, 200, 4, false, false))
         player.teleport(offsetLocation)
         return TeleportResult.SUCCESS
     }


### PR DESCRIPTION
To prevent players from unavoidably dying after a teleport due to the presence of mobs or players who are camping out a waystone to kill, players are now given Resistance 5 temporarily as a form of immunity.