### PR TITLE
Make use of the compass to open the warp menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Fluids are prevented from flowing into the teleport zone, as they can fill in the space after the blocks are cleared out.
 - Falling blocks are broken as they fall in to prevent filling the space back in with blocks after the existing blocks are cleared out.
 - Players are now given Resistance 5 on teleport for temporary invulnerability.
+- Warp menu can now be opened by right-clicking a compass.
 
 ### Changes
 - Text input in menus now defaults to blank.
 - Text input keeps the existing text in the box when the confirmation button is pressed and an error appears.
+- Warp list menu makes use of a new pagination system.
+- Actions are now cancelled when interacting with a waystone with item in hand.
 
 ## [0.1.0]
 - Initial Pre-Release for Minecraft 1.21.4. Watch out for bugs!

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -156,5 +156,6 @@ class WaystoneWarps: JavaPlugin() {
         server.pluginManager.registerEvents(MoveToolListener(), this)
         server.pluginManager.registerEvents(ToolRemovalListener(), this)
         server.pluginManager.registerEvents(TeleportZoneProtectionListener(), this)
+        server.pluginManager.registerEvents(WarpItemListener(), this)
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/WarpMenuCommand.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/WarpMenuCommand.kt
@@ -15,7 +15,7 @@ class WarpMenuCommand: BaseCommand() {
 
     @Default
     fun onWarp(player: Player, @Optional backCommand: String? = null) {
-        val menuNavigator = MenuNavigator()
+        val menuNavigator = MenuNavigator(player)
         WarpMenu(player, menuNavigator).open()
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
@@ -15,6 +15,11 @@ class WarpItemListener: Listener {
         val player = event.player
         val itemInHand = player.inventory.itemInMainHand
 
+        // Ignore if clicking on lodestone
+        if (event.clickedBlock?.type == Material.LODESTONE) {
+            return
+        }
+
         // Check if the item is a compass and the action is a right-click
         if (itemInHand.type == Material.COMPASS &&
                 (event.action == Action.RIGHT_CLICK_AIR || event.action == Action.RIGHT_CLICK_BLOCK)) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
@@ -1,0 +1,26 @@
+package dev.mizarc.waystonewarps.interaction.listeners
+
+import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
+import dev.mizarc.waystonewarps.interaction.menus.use.WarpMenu
+import org.bukkit.Material
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.block.Action
+import org.bukkit.event.player.PlayerInteractEvent
+
+class WarpItemListener: Listener {
+
+    @EventHandler
+    fun onWarpItemClick(event: PlayerInteractEvent) {
+        val player = event.player
+        val itemInHand = player.inventory.itemInMainHand
+
+        // Check if the item is a compass and the action is a right-click
+        if (itemInHand.type == Material.COMPASS &&
+                (event.action == Action.RIGHT_CLICK_AIR || event.action == Action.RIGHT_CLICK_BLOCK)) {
+            val menuNavigator = MenuNavigator()
+            val menu = WarpMenu(event.player, menuNavigator)
+            menuNavigator.openMenu(menu)
+        }
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
@@ -18,7 +18,7 @@ class WarpItemListener: Listener {
         // Check if the item is a compass and the action is a right-click
         if (itemInHand.type == Material.COMPASS &&
                 (event.action == Action.RIGHT_CLICK_AIR || event.action == Action.RIGHT_CLICK_BLOCK)) {
-            val menuNavigator = MenuNavigator()
+            val menuNavigator = MenuNavigator(player)
             val menu = WarpMenu(event.player, menuNavigator)
             menuNavigator.openMenu(menu)
         }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
@@ -36,6 +36,10 @@ class WaystoneInteractListener: Listener, KoinComponent {
         // Check for right click lodestone
         if (event.action != Action.RIGHT_CLICK_BLOCK || clickedBlock.type != Material.LODESTONE) return
 
+        // Check for holding compass
+        val itemInHand = event.player.inventory.itemInMainHand
+        if (itemInHand.type == Material.COMPASS) return
+
         // Check for smooth stone or barrier below lodestone
         val blockBelow: Block = clickedBlock.getRelative(BlockFace.DOWN)
         if (blockBelow.type != Material.SMOOTH_STONE && blockBelow.type != Material.BARRIER) return

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
@@ -49,6 +49,7 @@ class WaystoneInteractListener: Listener, KoinComponent {
         val menuNavigator = MenuNavigator(player)
 
         // Create new warp if not found, open management menu if owner, discover otherwise
+        event.isCancelled = true
         warp?.let {
             // Check if warp is locked and alert if no access
             if (warp.isLocked && warp.playerId != player.uniqueId

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
@@ -42,7 +42,7 @@ class WaystoneInteractListener: Listener, KoinComponent {
 
         // Check for existing warp
         val warp = getWarpAtPosition.execute(clickedBlock.location.toPosition3D(), clickedBlock.world.uid)
-        val menuNavigator = MenuNavigator()
+        val menuNavigator = MenuNavigator(player)
 
         // Create new warp if not found, open management menu if owner, discover otherwise
         warp?.let {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/MenuNavigator.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/MenuNavigator.kt
@@ -1,11 +1,12 @@
 package dev.mizarc.waystonewarps.interaction.menus
 
+import org.bukkit.entity.Player
 import kotlin.collections.ArrayDeque
 
 /**
  * A menu hook to store navigated menus and allow for backwards travel.
  */
-class MenuNavigator {
+class MenuNavigator(private val player: Player) {
     private val menuStack = ArrayDeque<Menu>()
 
     /**
@@ -61,6 +62,8 @@ class MenuNavigator {
             if (menuStack.isNotEmpty()) {
                 menuStack.first().passData(data)
                 menuStack.first().open()
+            } else {
+                player.closeInventory()
             }
         }
     }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -2,7 +2,6 @@ package dev.mizarc.waystonewarps.interaction.menus.use
 
 import com.github.stefvanschie.inventoryframework.gui.GuiItem
 import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
-import com.github.stefvanschie.inventoryframework.gui.type.util.Gui
 import com.github.stefvanschie.inventoryframework.pane.OutlinePane
 import com.github.stefvanschie.inventoryframework.pane.PaginatedPane
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
@@ -13,21 +12,17 @@ import dev.mizarc.waystonewarps.application.actions.whitelist.GetWhitelistedPlay
 import dev.mizarc.waystonewarps.domain.warps.Warp
 import dev.mizarc.waystonewarps.interaction.menus.Menu
 import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
-import dev.mizarc.waystonewarps.interaction.menus.management.ConfirmationMenu
 import dev.mizarc.waystonewarps.interaction.messaging.AccentColourPalette
 import dev.mizarc.waystonewarps.interaction.messaging.PrimaryColourPalette
 import dev.mizarc.waystonewarps.interaction.models.toViewModel
-import dev.mizarc.waystonewarps.interaction.utils.createHead
 import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
 import net.kyori.adventure.text.Component
-import org.bukkit.OfflinePlayer
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import kotlin.math.ceil
 
 class WarpMenu(private val player: Player, private val menuNavigator: MenuNavigator): Menu, KoinComponent {
     private val getPlayerWarpAccess: GetPlayerWarpAccess by inject()


### PR DESCRIPTION
Right clicking with a compass now opens the warp menu, which features the new pagination system that is also being used by the warp player menu. To avoid conflict, item usage is also cancelled when interacting with the waystone, which includes opening the warp list menu.