### PR TITLE
Add sample config generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Sounds are played for vault creation and discovery.
 - Sounds are played for the player being teleported and arriving at their destination.
 - Sounds are played for changing the skin of the waystone.
+- A sample-config.yml file is generated fresh on every launch to ensure that the most update to date base config format is known to administrators.
 
 ### Changed
 - The base of the waystone is now a slab rather than a barrier, making the space above the slab clickable to set the skin.

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -45,6 +45,11 @@ import net.milkbowl.vault.economy.Economy
 import org.bukkit.Bukkit
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 class WaystoneWarps: JavaPlugin() {
     private lateinit var commandManager: PaperCommandManager
@@ -81,7 +86,7 @@ class WaystoneWarps: JavaPlugin() {
         commandManager = PaperCommandManager(this)
 
         // Initialise everything else
-        saveDefaultConfig()
+        initialiseConfig()
         initialiseVaultDependency()
         initialiseRepositories()
         initialiseServices()
@@ -107,6 +112,18 @@ class WaystoneWarps: JavaPlugin() {
             server.servicesManager.getRegistration(Economy::class.java)?.let {economy = it.provider}
             logger.info(Chat::class.java.toString())
         }
+    }
+
+    private fun initialiseConfig() {
+        saveDefaultConfig()
+        getResource("config.yml")?.use { defaultConfigStream ->
+            val sampleConfigFile = File(dataFolder, "sample-config.yml")
+            try {
+                Files.copy(defaultConfigStream, sampleConfigFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            } catch (e: IOException) {
+                logger.severe("Failed to copy config: ${e.message}")
+            }
+        } ?: logger.warning("Default config file not found in the plugin resources")
     }
 
     private fun initialiseRepositories() {


### PR DESCRIPTION
This one was quite easy to implement, just ensure that the config file is copied into sample-config.yml on every launch, with replacement to ensure it always gets overwritten.