### PR TITLE
Add search, filter, and options to warp menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [Latest]
 
 ### Added
+- Warp menu contains filters to switch between discovered, favourites, and owned.
+- Search can be used to narrow down the list of discovered warps.
+- Warp sub-menu can be used to delete, favourite, or point the currently held compass to the direction of the warp.
 - Waystones can have their appearance changed by clicking on the base of the block with a valid block.
 - Waystones can also have their appearance changed on creation by placing down the lodestone on a valid block type.
 - Valid block skins are displayed on the "View Available Skins" submenu of the management menu.
@@ -20,6 +23,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 - The base of the waystone is now a slab rather than a barrier, making the space above the slab clickable to set the skin.
+- Lists of players and warps are sorted alphabetically.
 
 ## [0.2.0]
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -3,6 +3,7 @@ package dev.mizarc.waystonewarps
 import co.aikar.commands.PaperCommandManager
 import co.aikar.idb.Database
 import dev.mizarc.waystonewarps.application.actions.discovery.DiscoverWarp
+import dev.mizarc.waystonewarps.application.actions.discovery.GetFavouritedWarpAccess
 import dev.mizarc.waystonewarps.application.actions.teleport.LogPlayerMovement
 import dev.mizarc.waystonewarps.application.actions.teleport.TeleportPlayer
 import dev.mizarc.waystonewarps.application.actions.world.BreakWarpBlock
@@ -14,6 +15,7 @@ import dev.mizarc.waystonewarps.application.actions.discovery.IsPlayerFavouriteW
 import dev.mizarc.waystonewarps.application.actions.discovery.RevokeDiscovery
 import dev.mizarc.waystonewarps.application.actions.discovery.ToggleFavouriteDiscovery
 import dev.mizarc.waystonewarps.application.actions.management.GetAllWarpSkins
+import dev.mizarc.waystonewarps.application.actions.management.GetOwnedWarps
 import dev.mizarc.waystonewarps.application.actions.management.ToggleLock
 import dev.mizarc.waystonewarps.application.actions.world.RefreshAllStructures
 import dev.mizarc.waystonewarps.application.actions.management.UpdateWarpIcon
@@ -176,6 +178,8 @@ class WaystoneWarps: JavaPlugin() {
             single { GetAllWarpSkins(configService) }
             single { IsPlayerFavouriteWarp(discoveryRepository) }
             single { ToggleFavouriteDiscovery(discoveryRepository) }
+            single { GetFavouritedWarpAccess(discoveryRepository, warpRepository) }
+            single { GetOwnedWarps(warpRepository) }
         }
 
         startKoin { modules(actions) }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -10,7 +10,9 @@ import dev.mizarc.waystonewarps.application.actions.world.CreateWarp
 import dev.mizarc.waystonewarps.application.actions.discovery.GetPlayerWarpAccess
 import dev.mizarc.waystonewarps.application.actions.world.GetWarpAtPosition
 import dev.mizarc.waystonewarps.application.actions.discovery.GetWarpPlayerAccess
+import dev.mizarc.waystonewarps.application.actions.discovery.IsPlayerFavouriteWarp
 import dev.mizarc.waystonewarps.application.actions.discovery.RevokeDiscovery
+import dev.mizarc.waystonewarps.application.actions.discovery.ToggleFavouriteDiscovery
 import dev.mizarc.waystonewarps.application.actions.management.GetAllWarpSkins
 import dev.mizarc.waystonewarps.application.actions.management.ToggleLock
 import dev.mizarc.waystonewarps.application.actions.world.RefreshAllStructures
@@ -47,7 +49,6 @@ import org.koin.core.context.startKoin
 import org.koin.dsl.module
 import java.io.File
 import java.io.IOException
-import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
@@ -173,6 +174,8 @@ class WaystoneWarps: JavaPlugin() {
             single { UpdateWarpSkin(warpRepository, structureBuilderService, configService) }
             single { IsValidWarpBase(configService) }
             single { GetAllWarpSkins(configService) }
+            single { IsPlayerFavouriteWarp(discoveryRepository) }
+            single { ToggleFavouriteDiscovery(discoveryRepository) }
         }
 
         startKoin { modules(actions) }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/discovery/GetFavouritedWarpAccess.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/discovery/GetFavouritedWarpAccess.kt
@@ -1,0 +1,22 @@
+package dev.mizarc.waystonewarps.application.actions.discovery
+
+import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
+import dev.mizarc.waystonewarps.domain.warps.Warp
+import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+import java.util.UUID
+
+class GetFavouritedWarpAccess(private val discoveryRepository: DiscoveryRepository,
+                          private val warpRepository: WarpRepository
+) {
+    fun execute(playerId: UUID): List<Warp> {
+        val discoveries = discoveryRepository.getByPlayer(playerId)
+        val warps = mutableListOf<Warp>()
+        for (discovery in discoveries) {
+            val warp = warpRepository.getById(discovery.warpId)
+            if (warp != null && discovery.isFavourite) {
+                warps.add(warp)
+            }
+        }
+        return warps
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/discovery/IsPlayerFavouriteWarp.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/discovery/IsPlayerFavouriteWarp.kt
@@ -1,0 +1,11 @@
+package dev.mizarc.waystonewarps.application.actions.discovery
+
+import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
+import java.util.UUID
+
+class IsPlayerFavouriteWarp(private val discoveryRepository: DiscoveryRepository) {
+    fun execute(playerId: UUID, warpId: UUID): Boolean {
+        val discovery = discoveryRepository.getByWarpAndPlayer(warpId, playerId) ?: return false
+        return discovery.isFavourite
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/discovery/ToggleFavouriteDiscovery.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/discovery/ToggleFavouriteDiscovery.kt
@@ -1,0 +1,13 @@
+package dev.mizarc.waystonewarps.application.actions.discovery
+
+import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
+import java.util.UUID
+
+class ToggleFavouriteDiscovery(private val discoveryRepository: DiscoveryRepository) {
+    fun execute(playerId: UUID, warpId: UUID): Boolean {
+        val discovery = discoveryRepository.getByWarpAndPlayer(warpId, playerId) ?: return false
+        discovery.isFavourite = true
+        discoveryRepository.update(discovery)
+        return true
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/discovery/ToggleFavouriteDiscovery.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/discovery/ToggleFavouriteDiscovery.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 class ToggleFavouriteDiscovery(private val discoveryRepository: DiscoveryRepository) {
     fun execute(playerId: UUID, warpId: UUID): Boolean {
         val discovery = discoveryRepository.getByWarpAndPlayer(warpId, playerId) ?: return false
-        discovery.isFavourite = true
+        discovery.isFavourite = !discovery.isFavourite
         discoveryRepository.update(discovery)
         return true
     }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/GetOwnedWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/GetOwnedWarps.kt
@@ -1,0 +1,12 @@
+package dev.mizarc.waystonewarps.application.actions.management
+
+import dev.mizarc.waystonewarps.domain.warps.Warp
+import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+import java.util.UUID
+
+class GetOwnedWarps(private val warpRepository: WarpRepository) {
+
+    fun execute(playerId: UUID): List<Warp> {
+        return warpRepository.getByPlayer(playerId)
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/common/ConfirmationMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/common/ConfirmationMenu.kt
@@ -1,4 +1,4 @@
-package dev.mizarc.waystonewarps.interaction.menus.management
+package dev.mizarc.waystonewarps.interaction.menus.common
 
 import com.github.stefvanschie.inventoryframework.gui.GuiItem
 import com.github.stefvanschie.inventoryframework.gui.type.HopperGui

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
@@ -57,7 +57,7 @@ class WarpPlayerMenu(private val player: Player, private val menuNavigator: Menu
             1 -> getPlayerWhitelistForWarp.execute(warp.id).map { Bukkit.getOfflinePlayer(it) }
             2 -> Bukkit.getOnlinePlayers().map { it as OfflinePlayer }
             else -> emptyList()
-        }.filter { it.uniqueId != warp.playerId }
+        }.filter { it.uniqueId != warp.playerId }.sortedBy { it.name }
 
         // Filter by player name if specified
         val filteredPlayers = if (playerNameSearch.isNotBlank()) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
@@ -72,6 +72,7 @@ class WarpPlayerMenu(private val player: Player, private val menuNavigator: Menu
 
         // Pane of players
         val playerPane = displayPlayers(filteredPlayers, warp, gui)
+        gui.addPane(playerPane)
 
         // Add paginator pane
         addPaginator(gui, playerPane.pages.coerceAtLeast(1), page) { newPage ->
@@ -80,7 +81,6 @@ class WarpPlayerMenu(private val player: Player, private val menuNavigator: Menu
         }
 
         // Display to GUI
-        gui.addPane(playerPane)
         gui.show(player)
     }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
@@ -262,15 +262,13 @@ class WarpPlayerMenu(private val player: Player, private val menuNavigator: Menu
                 // Opens confirmation menu to ask to revoke access
                 else if (guiEvent.isRightClick && getWarpPlayerAccess.execute(warp.id).contains(foundPlayer.uniqueId)) {
                     menuNavigator.openMenu(
-                        ConfirmationMenu(
-                            menuNavigator, player,
-                            "Revoke ${foundPlayer.name}'s access?"
-                        ) {
+                        ConfirmationMenu(menuNavigator, player, "Revoke ${foundPlayer.name}'s access?") {
                             revokeDiscovery.execute(foundPlayer.uniqueId, warp.id)
                             if (viewMode == 0) {
                                 currentPagePane.removeItem(guiPlayerItem)
                             }
-                        })
+                        }
+                    )
                 }
             }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
@@ -15,6 +15,7 @@ import dev.mizarc.waystonewarps.application.actions.whitelist.ToggleWhitelist
 import dev.mizarc.waystonewarps.domain.warps.Warp
 import dev.mizarc.waystonewarps.interaction.menus.Menu
 import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
+import dev.mizarc.waystonewarps.interaction.menus.common.ConfirmationMenu
 import dev.mizarc.waystonewarps.interaction.utils.createHead
 import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
@@ -260,14 +261,16 @@ class WarpPlayerMenu(private val player: Player, private val menuNavigator: Menu
 
                 // Opens confirmation menu to ask to revoke access
                 else if (guiEvent.isRightClick && getWarpPlayerAccess.execute(warp.id).contains(foundPlayer.uniqueId)) {
-                    menuNavigator.openMenu(ConfirmationMenu(menuNavigator, player,
-                        "Revoke ${foundPlayer.name}'s access?"
-                    ) {
-                        revokeDiscovery.execute(foundPlayer.uniqueId, warp.id)
-                        if (viewMode == 0) {
-                            currentPagePane.removeItem(guiPlayerItem)
-                        }
-                    })
+                    menuNavigator.openMenu(
+                        ConfirmationMenu(
+                            menuNavigator, player,
+                            "Revoke ${foundPlayer.name}'s access?"
+                        ) {
+                            revokeDiscovery.execute(foundPlayer.uniqueId, warp.id)
+                            if (viewMode == 0) {
+                                currentPagePane.removeItem(guiPlayerItem)
+                            }
+                        })
                 }
             }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -156,54 +156,65 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
                 customLore.add(2, "Left Click to teleport")
                 val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(customLore)
                 guiWarpItem = GuiItem(warpItem) {guiEvent ->
-                    teleportPlayer.execute(player.uniqueId, warp,
-                        onPending = {
-                            player.sendActionBar {
-                                Component.text("Teleporting to ").color(PrimaryColourPalette.INFO.color)
-                                    .append(Component.text(warp.name).color(AccentColourPalette.INFO.color))
-                                    .append(Component.text("... Don't move!").color(PrimaryColourPalette.INFO.color))
+
+
+                    if (guiEvent.isRightClick) {
+                        // Right click to open options
+                        menuNavigator.openMenu(WarpOptionsMenu(player, menuNavigator, warp))
+                    } else {
+                        // Left click to teleport
+                        teleportPlayer.execute(
+                            player.uniqueId, warp,
+                            onPending = {
+                                player.sendActionBar {
+                                    Component.text("Teleporting to ").color(PrimaryColourPalette.INFO.color)
+                                        .append(Component.text(warp.name).color(AccentColourPalette.INFO.color))
+                                        .append(
+                                            Component.text("... Don't move!").color(PrimaryColourPalette.INFO.color)
+                                        )
+                                }
+                            },
+                            onSuccess = {
+                                player.sendActionBar {
+                                    Component.text("Welcome to ").color(PrimaryColourPalette.SUCCESS.color)
+                                        .append(Component.text(warp.name).color(AccentColourPalette.SUCCESS.color))
+                                        .append(Component.text("!").color(PrimaryColourPalette.SUCCESS.color))
+                                }
+                            },
+                            onFailure = {
+                                player.sendActionBar {
+                                    Component.text("Failed to teleport, contact the server administrator")
+                                        .color(PrimaryColourPalette.FAILED.color)
+                                }
+                            },
+                            onInsufficientFunds = {
+                                player.sendActionBar {
+                                    Component.text("Insufficient funds to teleport")
+                                        .color(PrimaryColourPalette.CANCELLED.color)
+                                }
+                            },
+                            onWorldNotFound = {
+                                player.sendActionBar {
+                                    Component.text("Cannot teleport to a world that does not exist")
+                                        .color(PrimaryColourPalette.FAILED.color)
+                                }
+                            },
+                            onLocked = {
+                                player.sendActionBar {
+                                    Component.text("Cannot teleport to a warp that is now locked")
+                                        .color(PrimaryColourPalette.CANCELLED.color)
+                                }
+                            },
+                            onCanceled = {
+                                player.sendActionBar {
+                                    Component.text("Cancelled teleport due to movement")
+                                        .color(PrimaryColourPalette.CANCELLED.color)
+                                }
                             }
-                        },
-                        onSuccess = {
-                            player.sendActionBar {
-                                Component.text("Welcome to ").color(PrimaryColourPalette.SUCCESS.color)
-                                    .append(Component.text(warp.name).color(AccentColourPalette.SUCCESS.color))
-                                    .append(Component.text("!").color(PrimaryColourPalette.SUCCESS.color))
-                            }
-                        },
-                        onFailure = {
-                            player.sendActionBar {
-                                Component.text("Failed to teleport, contact the server administrator")
-                                    .color(PrimaryColourPalette.FAILED.color)
-                            }
-                        },
-                        onInsufficientFunds = {
-                            player.sendActionBar {
-                                Component.text("Insufficient funds to teleport")
-                                    .color(PrimaryColourPalette.CANCELLED.color)
-                            }
-                        },
-                        onWorldNotFound = {
-                            player.sendActionBar {
-                                Component.text("Cannot teleport to a world that does not exist")
-                                    .color(PrimaryColourPalette.FAILED.color)
-                            }
-                        },
-                        onLocked = {
-                            player.sendActionBar {
-                                Component.text("Cannot teleport to a warp that is now locked")
-                                    .color(PrimaryColourPalette.CANCELLED.color)
-                            }
-                        },
-                        onCanceled = {
-                            player.sendActionBar {
-                                Component.text("Cancelled teleport due to movement")
-                                    .color(PrimaryColourPalette.CANCELLED.color)
-                            }
-                        }
-                    )
-                    player.closeInventory()
-                    guiEvent.isCancelled = true
+                        )
+                        player.closeInventory()
+                        guiEvent.isCancelled = true
+                    }
                 }
             }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -133,6 +133,7 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
         val playerPane = PaginatedPane(1, 2, 7, 3)
         var currentPagePane = OutlinePane(0, 0, 7, 3)
         var playerCounter = 0
+        val stockLore = listOf("Right Click for additional options")
 
         for (warp in warps) {
             val warpModel = warp.toViewModel()
@@ -141,21 +142,19 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             } ?: run {
                 "Location not found"
             }
+            val customLore = stockLore.toMutableList()
+            customLore.add(0, "§3$locationText")
+            customLore.add(0, "§6${warpModel.player.name}")
 
             var guiWarpItem: GuiItem
             if (warp.isLocked && !getWhitelistedPlayers.execute(warp.id).contains(player.uniqueId)) {
-                val lore = listOf(
-                    "§6${warpModel.player.name}",
-                    "§3$locationText",
-                    "§cLOCKED",
-                )
-                val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(lore)
+                customLore.add(2, "§cLOCKED")
+                val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(customLore)
                 guiWarpItem = GuiItem(warpItem) { open() }
             }
             else {
-                val warpItem = ItemStack(warpModel.icon).name(warpModel.name)
-                    .lore("§6${warpModel.player.name}")
-                    .lore("§3$locationText")
+                customLore.add(2, "Left Click to teleport")
+                val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(customLore)
                 guiWarpItem = GuiItem(warpItem) {guiEvent ->
                     teleportPlayer.execute(player.uniqueId, warp,
                         onPending = {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -145,9 +145,9 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             var guiWarpItem: GuiItem
             if (warp.isLocked && !getWhitelistedPlayers.execute(warp.id).contains(player.uniqueId)) {
                 val lore = listOf(
-                    warpModel.player.name.toString(),
-                    "§6$locationText",
-                    "&cLOCKED",
+                    "§6${warpModel.player.name}",
+                    "§3$locationText",
+                    "§cLOCKED",
                 )
                 val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(lore)
                 guiWarpItem = GuiItem(warpItem) { open() }
@@ -155,7 +155,7 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             else {
                 val warpItem = ItemStack(warpModel.icon).name(warpModel.name)
                     .lore("§6${warpModel.player.name}")
-                    .lore(locationText)
+                    .lore("§3$locationText")
                 guiWarpItem = GuiItem(warpItem) {guiEvent ->
                     teleportPlayer.execute(player.uniqueId, warp,
                         onPending = {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -6,12 +6,15 @@ import com.github.stefvanschie.inventoryframework.pane.OutlinePane
 import com.github.stefvanschie.inventoryframework.pane.PaginatedPane
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
 import com.github.stefvanschie.inventoryframework.pane.util.Mask
+import dev.mizarc.waystonewarps.application.actions.discovery.GetFavouritedWarpAccess
 import dev.mizarc.waystonewarps.application.actions.teleport.TeleportPlayer
 import dev.mizarc.waystonewarps.application.actions.discovery.GetPlayerWarpAccess
+import dev.mizarc.waystonewarps.application.actions.management.GetOwnedWarps
 import dev.mizarc.waystonewarps.application.actions.whitelist.GetWhitelistedPlayers
 import dev.mizarc.waystonewarps.domain.warps.Warp
 import dev.mizarc.waystonewarps.interaction.menus.Menu
 import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
+import dev.mizarc.waystonewarps.interaction.menus.management.PlayerSearchMenu
 import dev.mizarc.waystonewarps.interaction.messaging.AccentColourPalette
 import dev.mizarc.waystonewarps.interaction.messaging.PrimaryColourPalette
 import dev.mizarc.waystonewarps.interaction.models.toViewModel
@@ -20,7 +23,10 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
+import me.xdrop.fuzzywuzzy.FuzzySearch
 import net.kyori.adventure.text.Component
+import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -28,25 +34,59 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
     private val getPlayerWarpAccess: GetPlayerWarpAccess by inject()
     private val teleportPlayer: TeleportPlayer by inject()
     private val getWhitelistedPlayers: GetWhitelistedPlayers by inject()
+    private val getFavouritedWarpAccess: GetFavouritedWarpAccess by inject()
+    private val getOwnedWarps: GetOwnedWarps by inject()
 
+    private var viewMode = 0  // 0 = All, Favourites, Owned
     private var page = 1
+    private var warpNameSearch: String = ""
 
     override fun open() {
-        val warps = getPlayerWarpAccess.execute(player.uniqueId)
         val gui = ChestGui(6, "Warps")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
 
         // Add controls pane
-        val controlsPane = StaticPane(0, 0, 9, 1)
-        gui.addPane(controlsPane)
+        addControlsSection(gui)
 
-        // Add go back/exit item
-        val guiExitItem: GuiItem
-        val exitItem = ItemStack(Material.NETHER_STAR)
-            .name("Exit")
-        guiExitItem = GuiItem(exitItem) { menuNavigator.goBack() }
-        controlsPane.addItem(guiExitItem, 0, 0)
+        // Switch what warps to display depending on view mode
+        val warps = when (viewMode) {
+            0 -> getPlayerWarpAccess.execute(player.uniqueId)
+            1 -> getFavouritedWarpAccess.execute(player.uniqueId)
+            2 -> getOwnedWarps.execute(player.uniqueId)
+            else -> emptyList()
+        }
 
+        // Filter by warp name if specified
+        val filteredWarps = if (warpNameSearch.isNotBlank()) {
+            val playerNames = warps.map { it.name }
+            val searchResults = FuzzySearch.extractAll(warpNameSearch, playerNames)
+                .filter { it.score >= 60 }
+                .take(21)
+            searchResults.mapNotNull { result -> warps.find { it.name == result.string } }
+        } else {
+            warps
+        }
+
+        // Display warps
+        val warpPane = displayWarps(filteredWarps)
+        gui.addPane(warpPane)
+
+        // Add warp paginator
+        addPaginator(gui, warpPane.pages.coerceAtLeast(1), page) { newPage ->
+            page = newPage
+            warpPane.page = page - 1 // Subtract 1 since pages start at 0
+        }
+
+        gui.show(player)
+    }
+
+    override fun passData(data: Any?) {
+        if (data is String) {
+            warpNameSearch = data
+        }
+    }
+
+    private fun addControlsSection(gui: ChestGui): StaticPane {
         // Add outline
         val outlinePane = OutlinePane(0, 1, 9, 5)
         val dividerItem = ItemStack(Material.BLACK_STAINED_GLASS_PANE).name(" ")
@@ -62,17 +102,58 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
         outlinePane.setRepeat(true)
         gui.addPane(outlinePane)
 
-        // Display warps
-        val warpPane = displayWarps(getPlayerWarpAccess.execute(player.uniqueId))
-        gui.addPane(warpPane)
+        // Add controls pane
+        val controlsPane = StaticPane(0, 0, 6, 1)
+        gui.addPane(controlsPane)
 
-        // Add warp paginator
-        addPaginator(gui, warpPane.pages.coerceAtLeast(1), page) { newPage ->
-            page = newPage
-            warpPane.page = page - 1 // Subtract 1 since pages start at 0
+        // Add go back item
+        val exitItem = ItemStack(Material.NETHER_STAR).name("Exit")
+        val guiExitItem = GuiItem(exitItem) { menuNavigator.goBack() }
+        controlsPane.addItem(guiExitItem, 0, 0)
+
+        // Add view mode item
+        val viewModeItem = when (viewMode) {
+            0 -> ItemStack(Material.SUGAR)
+                .name("Discovered")
+                .lore("Listing all of your discovered warps")
+            1 -> ItemStack(Material.GLOWSTONE_DUST)
+                .name("Favourited")
+                .lore("Listing only favourited warps")
+            else -> ItemStack(Material.REDSTONE)
+                .name("Owned")
+                .lore("Listing only warps that you own")
+        }
+        val guiViewModeItem = GuiItem(viewModeItem) { guiEvent ->
+            // Cycle through 0, 1, 2
+            viewMode = when (guiEvent.isLeftClick) {
+                true -> (viewMode + 1) % 3 // Cycle forwards on left click
+                false -> (viewMode - 1 + 3) % 3 // Cycle backwards on right click
+            }
+            page = 1
+            open()
+        }
+        controlsPane.addItem(guiViewModeItem, 2, 0)
+
+        // Add search button
+        val searchItem = ItemStack(Material.NAME_TAG).name("Search")
+        val guiSearchItem = GuiItem(searchItem) {
+            val warpSearchMenu = WarpSearchMenu(player, menuNavigator)
+            menuNavigator.openMenu(warpSearchMenu)
+        }
+        controlsPane.addItem(guiSearchItem, 3, 0)
+
+        // Add clear search button
+        if (warpNameSearch.isNotEmpty()) {
+            val clearSearchItem = ItemStack(Material.MAGMA_CREAM).name("Clear Search")
+            val guiClearSearchItem = GuiItem(clearSearchItem) {
+                warpNameSearch = ""
+                page = 1
+                open()
+            }
+            controlsPane.addItem(guiClearSearchItem, 4, 0)
         }
 
-        gui.show(player)
+        return controlsPane
     }
 
     private fun addPaginator(gui: ChestGui, totalPages: Int, page: Int, updateContent: (Int) -> Unit) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -150,13 +150,17 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             if (warp.isLocked && !getWhitelistedPlayers.execute(warp.id).contains(player.uniqueId)) {
                 customLore.add(2, "§cLOCKED")
                 val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(customLore)
-                guiWarpItem = GuiItem(warpItem) { open() }
+                guiWarpItem = GuiItem(warpItem) { guiEvent ->
+                    if (guiEvent.isRightClick) {
+                        // Right click to open options
+                        menuNavigator.openMenu(WarpOptionsMenu(player, menuNavigator, warp))
+                    }
+                }
             }
             else {
                 customLore.add(2, "Left Click to teleport")
                 val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(customLore)
                 guiWarpItem = GuiItem(warpItem) {guiEvent ->
-
 
                     if (guiEvent.isRightClick) {
                         // Right click to open options

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -145,14 +145,17 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             var guiWarpItem: GuiItem
             if (warp.isLocked && !getWhitelistedPlayers.execute(warp.id).contains(player.uniqueId)) {
                 val lore = listOf(
-                    locationText,
+                    warpModel.player.name.toString(),
+                    "§6$locationText",
                     "&cLOCKED",
                 )
                 val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(lore)
                 guiWarpItem = GuiItem(warpItem) { open() }
             }
             else {
-                val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(locationText)
+                val warpItem = ItemStack(warpModel.icon).name(warpModel.name)
+                    .lore("§6${warpModel.player.name}")
+                    .lore(locationText)
                 guiWarpItem = GuiItem(warpItem) {guiEvent ->
                     teleportPlayer.execute(player.uniqueId, warp,
                         onPending = {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -54,7 +54,7 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             1 -> getFavouritedWarpAccess.execute(player.uniqueId)
             2 -> getOwnedWarps.execute(player.uniqueId)
             else -> emptyList()
-        }
+        }.sortedBy { it.name }
 
         // Filter by warp name if specified
         val filteredWarps = if (warpNameSearch.isNotBlank()) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
@@ -70,14 +70,22 @@ class WarpOptionsMenu(private val player: Player, private val menuNavigator: Men
 
         // Add delete menu item
         // Add favourite menu item
-        val deleteItem = ItemStack(Material.FIRE_CHARGE)
-            .name("Delete")
-            .lore("Removes your access to this warp")
-        val guiDeleteItem = GuiItem(deleteItem) { guiEvent ->
-            menuNavigator.openMenu(ConfirmationMenu(menuNavigator, player, "Delete access to ${warp.name}") {
-                revokeDiscovery.execute(player.uniqueId, warp.id)
-                menuNavigator.goBack()
-            })
+        val guiDeleteItem: GuiItem
+        if (warp.playerId == player.uniqueId) {
+            val deleteItem = ItemStack(Material.SNOWBALL)
+                .name("Cannot Delete")
+                .lore("You own this warp!")
+            guiDeleteItem = GuiItem(deleteItem)
+        } else {
+            val deleteItem = ItemStack(Material.FIRE_CHARGE)
+                .name("Delete")
+                .lore("Removes your access to this warp")
+            guiDeleteItem = GuiItem(deleteItem) { guiEvent ->
+                menuNavigator.openMenu(ConfirmationMenu(menuNavigator, player, "Delete access to ${warp.name}") {
+                    revokeDiscovery.execute(player.uniqueId, warp.id)
+                    menuNavigator.goBack()
+                })
+            }
         }
         pane.addItem(guiDeleteItem, 4, 0)
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
@@ -44,13 +44,23 @@ class WarpOptionsMenu(private val player: Player, private val menuNavigator: Men
         pane.addItem(guiBackItem, 0, 0)
 
         // Add point menu item
-        val pointItem = ItemStack(Material.COMPASS)
-            .name("Point to Waystone")
-            .lore("Your compass will point towards this waystone")
-        val guiPointItem = GuiItem(pointItem) { guiEvent ->
-            givePlayerLodestoneCompass()
+        val guiPointItem: GuiItem
+        if (player.inventory.itemInMainHand.type == Material.COMPASS) {
+            val pointItem = ItemStack(Material.COMPASS)
+                .name("Locate Waystone")
+                .lore("Your compass will point towards this waystone")
+            guiPointItem = GuiItem(pointItem) { guiEvent ->
+                givePlayerLodestoneCompass()
+            }
+            pane.addItem(guiPointItem, 2, 0)
         }
-        pane.addItem(guiPointItem, 2, 0)
+        else {
+            val pointItem = ItemStack(Material.WIND_CHARGE)
+                .name("No Compass")
+                .lore("Hold a compass in hand to use the waystone locator")
+            guiPointItem = GuiItem(pointItem)
+            pane.addItem(guiPointItem, 2, 0)
+        }
 
         // Add favourite menu item
         val favouriteItem = if (isPlayerFavouriteWarp.execute(player.uniqueId, warp.id)) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
@@ -103,7 +103,7 @@ class WarpOptionsMenu(private val player: Player, private val menuNavigator: Men
 
             // Set lodestone details
             meta.lodestone = warp.position.toLocation(world)
-            meta.isLodestoneTracked = true
+            meta.isLodestoneTracked = false
 
             compass.itemMeta = meta
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
@@ -56,11 +56,11 @@ class WarpOptionsMenu(private val player: Player, private val menuNavigator: Men
         val favouriteItem = if (isPlayerFavouriteWarp.execute(player.uniqueId, warp.id)) {
             ItemStack(Material.DIAMOND)
                 .name("Unfavourite")
-                .lore("Deprioritises placement in the menu")
+                .lore("Removes this warp from the favourites list")
         } else {
             ItemStack(Material.COAL)
                 .name("Favourite")
-                .lore("Prioritises placement in the menu")
+                .lore("Adds this warp to the favourites list")
         }
         val guiFavouriteItem = GuiItem(favouriteItem) { guiEvent ->
             toggleFavouriteDiscovery.execute(player.uniqueId, warp.id)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
@@ -1,0 +1,106 @@
+package dev.mizarc.waystonewarps.interaction.menus.use
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.HopperGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import dev.mizarc.waystonewarps.application.actions.discovery.IsPlayerFavouriteWarp
+import dev.mizarc.waystonewarps.application.actions.discovery.RevokeDiscovery
+import dev.mizarc.waystonewarps.application.actions.discovery.ToggleFavouriteDiscovery
+import dev.mizarc.waystonewarps.domain.warps.Warp
+import dev.mizarc.waystonewarps.infrastructure.mappers.toLocation
+import dev.mizarc.waystonewarps.interaction.menus.Menu
+import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
+import dev.mizarc.waystonewarps.interaction.menus.common.ConfirmationMenu
+import dev.mizarc.waystonewarps.interaction.utils.lore
+import dev.mizarc.waystonewarps.interaction.utils.name
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.CompassMeta
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class WarpOptionsMenu(private val player: Player, private val menuNavigator: MenuNavigator, private val warp: Warp): Menu, KoinComponent {
+    private val revokeDiscovery: RevokeDiscovery by inject()
+    private val isPlayerFavouriteWarp: IsPlayerFavouriteWarp by inject()
+    private val toggleFavouriteDiscovery: ToggleFavouriteDiscovery by inject()
+
+    override fun open() {
+        // Create menu
+        val gui = HopperGui("Warp ${warp.name}")
+        val pane = StaticPane(0, 0, 5, 1)
+        gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
+        gui.slotsComponent.addPane(pane)
+
+        // Add back menu item
+        val backItem = ItemStack(Material.NETHER_STAR).name("Go Back")
+        val guiBackItem = GuiItem(backItem) { guiEvent ->
+            menuNavigator.goBack()
+        }
+        pane.addItem(guiBackItem, 0, 0)
+
+        // Add point menu item
+        val pointItem = ItemStack(Material.COMPASS)
+            .name("Point to Waystone")
+            .lore("Your compass will point towards this waystone")
+        val guiPointItem = GuiItem(pointItem) { guiEvent ->
+            givePlayerLodestoneCompass()
+        }
+        pane.addItem(guiPointItem, 2, 0)
+
+        // Add favourite menu item
+        val favouriteItem = if (isPlayerFavouriteWarp.execute(player.uniqueId, warp.id)) {
+            ItemStack(Material.DIAMOND)
+                .name("Unfavourite")
+                .lore("Deprioritises placement in the menu")
+        } else {
+            ItemStack(Material.COAL)
+                .name("Favourite")
+                .lore("Prioritises placement in the menu")
+        }
+        val guiFavouriteItem = GuiItem(favouriteItem) { guiEvent ->
+            toggleFavouriteDiscovery.execute(player.uniqueId, warp.id)
+            open()
+        }
+        pane.addItem(guiFavouriteItem, 3, 0)
+
+        // Add delete menu item
+        // Add favourite menu item
+        val deleteItem = ItemStack(Material.FIRE_CHARGE)
+            .name("Delete")
+            .lore("Removes your access to this warp")
+        val guiDeleteItem = GuiItem(deleteItem) { guiEvent ->
+            menuNavigator.openMenu(ConfirmationMenu(menuNavigator, player, "Delete access to ${warp.name}") {
+                revokeDiscovery.execute(player.uniqueId, warp.id)
+                menuNavigator.goBack()
+            })
+        }
+        pane.addItem(guiDeleteItem, 4, 0)
+
+        gui.show(player)
+    }
+
+    private fun givePlayerLodestoneCompass() {
+        val world = Bukkit.getWorld(warp.worldId) ?: return
+        val heldItem = player.inventory.itemInMainHand
+
+        if (heldItem.type == Material.COMPASS) {
+            // Create the Lodestone Compass
+            val compass = ItemStack(Material.COMPASS)
+            val meta = compass.itemMeta as CompassMeta
+
+            // Set lodestone details
+            meta.lodestone = warp.position.toLocation(world)
+            meta.isLodestoneTracked = true
+
+            compass.itemMeta = meta
+
+            // Replace the currently held item
+            player.inventory.setItemInMainHand(compass)
+        }
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpOptionsMenu.kt
@@ -29,7 +29,7 @@ class WarpOptionsMenu(private val player: Player, private val menuNavigator: Men
 
     override fun open() {
         // Create menu
-        val gui = HopperGui("Warp ${warp.name}")
+        val gui = HopperGui("Warp '${warp.name}'")
         val pane = StaticPane(0, 0, 5, 1)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpSearchMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpSearchMenu.kt
@@ -1,0 +1,41 @@
+package dev.mizarc.waystonewarps.interaction.menus.use
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.AnvilGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import dev.mizarc.waystonewarps.interaction.menus.Menu
+import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
+import dev.mizarc.waystonewarps.interaction.utils.name
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
+
+class WarpSearchMenu(private val player: Player, private val menuNavigator: MenuNavigator): Menu {
+
+    override fun open() {
+        // Create menu
+        val gui = AnvilGui("Search for warp")
+        gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
+
+        // Add lodestone menu item
+        val firstPane = StaticPane(0, 0, 1, 1)
+        val headItem = ItemStack(Material.LODESTONE).name("")
+        val guiHeadItem = GuiItem(headItem) { guiEvent -> guiEvent.isCancelled = true }
+        firstPane.addItem(guiHeadItem, 0, 0)
+        gui.firstItemComponent.addPane(firstPane)
+
+        // Add confirm menu item.
+        val thirdPane = StaticPane(0, 0, 1, 1)
+        val confirmItem = ItemStack(Material.NETHER_STAR).name("Confirm")
+        val confirmGuiItem = GuiItem(confirmItem) { _ ->
+            menuNavigator.goBackWithData(gui.renameText)
+        }
+        thirdPane.addItem(confirmGuiItem, 0, 0)
+        gui.resultComponent.addPane(thirdPane)
+
+        gui.show(player)
+    }
+}


### PR DESCRIPTION
This allows the player to organise their list of warps however they like, with the option to set filter warps by criteria. You can also right click to bring up additional options like using the compass in hand to locate the waystone in the world, set as favourite in the menu list, as well as delete your own access to the warp.