### PR TITLE
Add option to open the warps menu via right click waystone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Sounds are played for vault creation and discovery.
 - Sounds are played for the player being teleported and arriving at their destination.
 - Sounds are played for changing the skin of the waystone.
+- Config toggle to enable the functionality of using the compass to open the warp list menu.
+- Config toggle to enable the functionality of using the waystone to open the warp list menu, moving the management menu to shift+right click.
 - A sample-config.yml file is generated fresh on every launch to ensure that the most update to date base config format is known to administrators.
 
 ### Changed

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -190,13 +190,13 @@ class WaystoneWarps: JavaPlugin() {
     }
 
     private fun registerEvents() {
-        server.pluginManager.registerEvents(WaystoneInteractListener(), this)
+        server.pluginManager.registerEvents(WaystoneInteractListener(configService), this)
         server.pluginManager.registerEvents(WaystoneDestructionListener(), this)
         server.pluginManager.registerEvents(PlayerMovementListener(), this)
         server.pluginManager.registerEvents(MoveToolListener(), this)
         server.pluginManager.registerEvents(ToolRemovalListener(), this)
         server.pluginManager.registerEvents(TeleportZoneProtectionListener(), this)
-        server.pluginManager.registerEvents(WarpItemListener(), this)
+        server.pluginManager.registerEvents(WarpItemListener(configService), this)
         server.pluginManager.registerEvents(WaystoneBaseInteractListener(), this)
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/services/ConfigService.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/services/ConfigService.kt
@@ -11,4 +11,6 @@ interface ConfigService {
     fun getPlatformReplaceBlocks(): Set<String>
     fun getAllSkinTypes(): List<String>
     fun getStructureBlocks(blockType: String): List<String>
+    fun allowListMenuViaCompass(): Boolean
+    fun allowListMenuViaWaystone(): Boolean
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/services/ConfigService.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/services/ConfigService.kt
@@ -11,6 +11,6 @@ interface ConfigService {
     fun getPlatformReplaceBlocks(): Set<String>
     fun getAllSkinTypes(): List<String>
     fun getStructureBlocks(blockType: String): List<String>
-    fun allowListMenuViaCompass(): Boolean
-    fun allowListMenuViaWaystone(): Boolean
+    fun allowWarpsMenuViaCompass(): Boolean
+    fun allowWarpsMenuViaWaystone(): Boolean
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
@@ -2,10 +2,7 @@ package dev.mizarc.waystonewarps.infrastructure.services
 
 import dev.mizarc.waystonewarps.application.services.ConfigService
 import dev.mizarc.waystonewarps.infrastructure.services.teleportation.CostType
-import org.bukkit.Material
 import org.bukkit.configuration.file.FileConfiguration
-import org.bukkit.plugin.Plugin
-import java.io.File
 
 class ConfigServiceBukkit(private val configFile: FileConfiguration): ConfigService {
 
@@ -41,11 +38,11 @@ class ConfigServiceBukkit(private val configFile: FileConfiguration): ConfigServ
         return configFile.getStringList("waystone_skins.$blockType")
     }
 
-    override fun allowListMenuViaCompass(): Boolean {
+    override fun allowWarpsMenuViaCompass(): Boolean {
         return configFile.getBoolean("list_menu_via_compass")
     }
 
-    override fun allowListMenuViaWaystone(): Boolean {
+    override fun allowWarpsMenuViaWaystone(): Boolean {
         return configFile.getBoolean("list_menu_via_waystone")
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
@@ -40,4 +40,12 @@ class ConfigServiceBukkit(private val configFile: FileConfiguration): ConfigServ
     override fun getStructureBlocks(blockType: String): List<String> {
         return configFile.getStringList("waystone_skins.$blockType")
     }
+
+    override fun allowListMenuViaCompass(): Boolean {
+        return configFile.getBoolean("list_menu_via_compass")
+    }
+
+    override fun allowListMenuViaWaystone(): Boolean {
+        return configFile.getBoolean("list_menu_via_waystone")
+    }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
@@ -13,7 +13,7 @@ class WarpItemListener(private val configService: ConfigService): Listener {
 
     @EventHandler
     fun onWarpItemClick(event: PlayerInteractEvent) {
-        if (!configService.allowListMenuViaCompass()) return
+        if (!configService.allowWarpsMenuViaCompass()) return
 
         val player = event.player
         val itemInHand = player.inventory.itemInMainHand

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WarpItemListener.kt
@@ -1,5 +1,6 @@
 package dev.mizarc.waystonewarps.interaction.listeners
 
+import dev.mizarc.waystonewarps.application.services.ConfigService
 import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
 import dev.mizarc.waystonewarps.interaction.menus.use.WarpMenu
 import org.bukkit.Material
@@ -8,10 +9,12 @@ import org.bukkit.event.Listener
 import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerInteractEvent
 
-class WarpItemListener: Listener {
+class WarpItemListener(private val configService: ConfigService): Listener {
 
     @EventHandler
     fun onWarpItemClick(event: PlayerInteractEvent) {
+        if (!configService.allowListMenuViaCompass()) return
+
         val player = event.player
         val itemInHand = player.inventory.itemInMainHand
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
@@ -4,6 +4,7 @@ import dev.mizarc.waystonewarps.application.actions.discovery.DiscoverWarp
 import dev.mizarc.waystonewarps.application.actions.whitelist.GetWhitelistedPlayers
 import dev.mizarc.waystonewarps.application.actions.world.GetWarpAtPosition
 import dev.mizarc.waystonewarps.application.actions.world.IsValidWarpBase
+import dev.mizarc.waystonewarps.application.services.ConfigService
 import dev.mizarc.waystonewarps.infrastructure.mappers.toPosition3D
 import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
 import dev.mizarc.waystonewarps.interaction.menus.management.WarpManagementMenu
@@ -26,7 +27,7 @@ import org.bukkit.inventory.EquipmentSlot
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-class WaystoneInteractListener: Listener, KoinComponent {
+class WaystoneInteractListener(private val configService: ConfigService): Listener, KoinComponent {
     private val getWarpAtPosition: GetWarpAtPosition by inject()
     private val discoverWarp: DiscoverWarp by inject()
     private val getWhitelistedPlayers: GetWhitelistedPlayers by inject()

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
@@ -9,6 +9,7 @@ import dev.mizarc.waystonewarps.infrastructure.mappers.toPosition3D
 import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
 import dev.mizarc.waystonewarps.interaction.menus.management.WarpManagementMenu
 import dev.mizarc.waystonewarps.interaction.menus.management.WarpNamingMenu
+import dev.mizarc.waystonewarps.interaction.menus.use.WarpMenu
 import dev.mizarc.waystonewarps.interaction.messaging.AccentColourPalette
 import dev.mizarc.waystonewarps.interaction.messaging.PrimaryColourPalette
 import net.kyori.adventure.text.Component
@@ -65,7 +66,15 @@ class WaystoneInteractListener(private val configService: ConfigService): Listen
             particleLocation.z += 0.5
 
             if (it.playerId == player.uniqueId) {
-                menuNavigator.openMenu(WarpManagementMenu(player, menuNavigator, it))
+                if (configService.allowListMenuViaWaystone()) {
+                    if (event.player.isSneaking) {
+                        menuNavigator.openMenu(WarpManagementMenu(player, menuNavigator, it))
+                    } else {
+                        menuNavigator.openMenu(WarpMenu(player, menuNavigator))
+                    }
+                } else {
+                    menuNavigator.openMenu(WarpManagementMenu(player, menuNavigator, it))
+                }
             } else {
                 val result = discoverWarp.execute(player.uniqueId, it.id)
                 if (result) {
@@ -75,9 +84,14 @@ class WaystoneInteractListener(private val configService: ConfigService): Listen
                     clickedBlock.world.spawnParticle(Particle.TOTEM_OF_UNDYING, particleLocation, 20)
                     clickedBlock.world.playSound(particleLocation, Sound.BLOCK_AMETHYST_BLOCK_HIT, SoundCategory.BLOCKS, 1.0f, 1.0f)
                 } else {
-                    player.sendActionBar(Component.text("Warp ").color(PrimaryColourPalette.INFO.color)
-                        .append(Component.text(warp.name).color(AccentColourPalette.INFO.color))
-                        .append(Component.text( " already discovered").color(PrimaryColourPalette.INFO.color)))
+                    if (configService.allowListMenuViaWaystone()) {
+                        menuNavigator.openMenu(WarpMenu(player, menuNavigator))
+                    }
+                    else {
+                        player.sendActionBar(Component.text("Warp ").color(PrimaryColourPalette.INFO.color)
+                            .append(Component.text(warp.name).color(AccentColourPalette.INFO.color))
+                            .append(Component.text( " already discovered").color(PrimaryColourPalette.INFO.color)))
+                    }
                 }
             }
         }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
@@ -66,7 +66,7 @@ class WaystoneInteractListener(private val configService: ConfigService): Listen
             particleLocation.z += 0.5
 
             if (it.playerId == player.uniqueId) {
-                if (configService.allowListMenuViaWaystone()) {
+                if (configService.allowWarpsMenuViaWaystone()) {
                     if (event.player.isSneaking) {
                         menuNavigator.openMenu(WarpManagementMenu(player, menuNavigator, it))
                     } else {
@@ -84,7 +84,7 @@ class WaystoneInteractListener(private val configService: ConfigService): Listen
                     clickedBlock.world.spawnParticle(Particle.TOTEM_OF_UNDYING, particleLocation, 20)
                     clickedBlock.world.playSound(particleLocation, Sound.BLOCK_AMETHYST_BLOCK_HIT, SoundCategory.BLOCKS, 1.0f, 1.0f)
                 } else {
-                    if (configService.allowListMenuViaWaystone()) {
+                    if (configService.allowWarpsMenuViaWaystone()) {
                         menuNavigator.openMenu(WarpMenu(player, menuNavigator))
                     }
                     else {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,6 +19,13 @@ teleport_cost_item: ENDER_PEARL
 # Decimals can be used for money type.
 teleport_cost_amount: 4
 
+# If the player can open the warp list menu via right-clicking on a compass.
+list_menu_via_compass: true
+
+# If the player can open the warp list menu via right-clicking on a waystone.
+# This replaces warp management menu to be shift-right click instead.
+list_menu_via_waystone: false
+
 # The blocks that can be used to transform the waystone appearance. This
 # contains all the required blocks that make up the waystone that must be in the
 # following order:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,11 +20,11 @@ teleport_cost_item: ENDER_PEARL
 teleport_cost_amount: 4
 
 # If the player can open the warp list menu via right-clicking on a compass.
-list_menu_via_compass: true
+warps_menu_via_compass: true
 
 # If the player can open the warp list menu via right-clicking on a waystone.
 # This replaces warp management menu to be shift-right click instead.
-list_menu_via_waystone: false
+warps_menu_via_waystone: false
 
 # The blocks that can be used to transform the waystone appearance. This
 # contains all the required blocks that make up the waystone that must be in the


### PR DESCRIPTION
This is an optional config value which replaces the warp management menu on right clicking a waystone with the warps list menu. The management menu is moved to shift+right click when this is enabled.

The standard compass warps menu is also made toggleable in the config.