### PR TITLE
Fixed erroring when using invalid materials in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.1]
+
+### Fixed
+- Error when using invalid materials in the config. Invalid materials are now skipped over or set to default when required.
+
 ## [0.3.0]
 
 ### Added

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
@@ -23,68 +23,22 @@ import java.util.*
 class StructureBuilderServiceBukkit(private val plugin: Plugin, private val configService: ConfigService): StructureBuilderService {
 
     override fun spawnStructure(warp: Warp) {
-        // Get the structure blocks based on the block type
-        val structureBlocks = configService.getStructureBlocks(warp.block).takeIf { it.count() == 5 }
-            ?: listOf("SMOOTH_STONE", "LODESTONE", "SMOOTH_STONE", "SMOOTH_STONE", "SMOOTH_STONE_SLAB")
         val world = Bukkit.getWorld(warp.worldId) ?: return
-        val location = warp.position.toLocation(world)
-
-        // Replace top block with main block type
-        location.block.type = Material.valueOf(structureBlocks[1])
-
-        // Replace bottom block with slab
-        // Needs to be a 2 tick delay here because Bukkit is ass and spits out a stupid POI data mismatch error
-        object : BukkitRunnable() {
-            override fun run() {
-                world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ)
-                    .type = Material.valueOf(structureBlocks[4])
-            }
-        }.runTaskLater(plugin, 2L)
-
-        // Generate custom model
-        createBlockDisplay(warp.id, warp.position.toLocation(world), Material.valueOf(structureBlocks[0]),
-            0.075f, 1.3f, 0.075f,
-            0.85f, 0.85f, 0.85f)
-        createBlockDisplay(warp.id, warp.position.toLocation(world), Material.valueOf(structureBlocks[2]),
-            0.075f, 0.8f, 0.075f,
-            0.85f, 0.85f, 0.85f)
-        createBlockDisplay(warp.id, warp.position.toLocation(world), Material.valueOf(structureBlocks[3]),
-            0.2f, 0.4f, 0.2f,
-            0.6f, 0.6f, 0.6f)
+        val structureBlocks = getStructureBlocks(warp)
+        generateStructure(warp, structureBlocks, world)
     }
 
     override fun updateStructure(warp: Warp) {
-        val structureBlocks = configService.getStructureBlocks(warp.block).takeIf { it.count() == 5 }
-            ?: listOf("SMOOTH_STONE", "LODESTONE", "SMOOTH_STONE", "SMOOTH_STONE", "SMOOTH_STONE_SLAB")
         val world = Bukkit.getWorld(warp.worldId) ?: return
-        val location = warp.position.toLocation(world)
+        val structureBlocks = getStructureBlocks(warp)
 
-        // Replace top block with main block type
-        location.block.type = Material.valueOf(structureBlocks[1])
-
-        // Replace bottom block with slab
-        world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ)
-            .type = Material.valueOf(structureBlocks[4])
-
-        // Generate custom model
-        val entityList = mutableListOf<Entity>()
-        entityList.add(createBlockDisplay(warp.id, warp.position.toLocation(world), Material.valueOf(structureBlocks[0]),
-            0.075f, 1.3f, 0.075f,
-            0.85f, 0.85f, 0.85f))
-        entityList.add(createBlockDisplay(warp.id, warp.position.toLocation(world), Material.valueOf(structureBlocks[2]),
-            0.075f, 0.8f, 0.075f,
-            0.85f, 0.85f, 0.85f))
-        entityList.add(createBlockDisplay(warp.id, warp.position.toLocation(world), Material.valueOf(structureBlocks[3]),
-            0.2f, 0.4f, 0.2f,
-            0.6f, 0.6f, 0.6f))
-
-        // Remove existing block display after 2 ticks to ensure it doesn't disappear before new one is spawned
+        // Generate and then remove existing block display after 2 ticks to prevent flashing
+        val entityList = generateStructure(warp, structureBlocks, world)
         object : BukkitRunnable() {
             override fun run() {
                 removeBlockDisplay(warp, world, entityList)
             }
         }.runTaskLater(plugin, 2L)
-
     }
 
     override fun revertStructure(warp: Warp) {
@@ -102,13 +56,58 @@ class StructureBuilderServiceBukkit(private val plugin: Plugin, private val conf
         removeBlockDisplay(warp, world)
     }
 
+    private fun getStructureBlocks(warp: Warp): List<Material> {
+        val defaultStructureBlocks = listOf(Material.SMOOTH_STONE, Material.LODESTONE, Material.SMOOTH_STONE,
+            Material.SMOOTH_STONE, Material.SMOOTH_STONE_SLAB
+        )
+        return try {
+            val blocks = configService.getStructureBlocks(warp.block)
+            if (blocks.count() == 5) {
+                blocks.map { Material.valueOf(it) }
+            } else {
+                defaultStructureBlocks
+            }
+        } catch (_: IllegalArgumentException) {
+            defaultStructureBlocks
+        }
+    }
+
+    private fun generateStructure(warp: Warp, structureBlocks: List<Material>, world: World): MutableList<Entity> {
+        val location = warp.position.toLocation(world)
+        println(location)
+
+        // Replace top block with main block type
+        location.block.type = structureBlocks[1]
+
+        // Replace bottom block with slab (delay to avoid POI data mismatch error)
+        object : BukkitRunnable() {
+            override fun run() {
+                world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ).type = structureBlocks[4]
+            }
+        }.runTaskLater(plugin, 2L)
+
+        // Create and return entities
+        return mutableListOf(
+            createBlockDisplay(warp.id, location, structureBlocks[0],
+                0.075f, 1.3f, 0.075f,
+                0.85f, 0.85f, 0.85f),
+            createBlockDisplay(warp.id, location, structureBlocks[2],
+                0.075f, 0.8f, 0.075f,
+                0.85f, 0.85f, 0.85f),
+            createBlockDisplay(warp.id, location, structureBlocks[3],
+                0.2f, 0.4f, 0.2f,
+                0.6f, 0.6f, 0.6f)
+        )
+    }
+
     private fun createBlockDisplay(warpId: UUID, baseLocation: Location, material: Material,
                                    offsetX: Float, offsetY: Float, offsetZ: Float,
                                    scaleX: Float, scaleY: Float, scaleZ: Float): Entity {
         // Create BlockData
         val blockData = material.createBlockData()
-        baseLocation.y -= 1
-        val blockDisplay = baseLocation.world.spawnEntity(baseLocation, EntityType.BLOCK_DISPLAY) as BlockDisplay
+        val location = baseLocation.clone()
+        location.y -= 1
+        val blockDisplay = baseLocation.world.spawnEntity(location, EntityType.BLOCK_DISPLAY) as BlockDisplay
         blockDisplay.block = blockData
 
         // Transform display

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/teleportation/TeleportationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/teleportation/TeleportationServiceBukkit.kt
@@ -242,9 +242,10 @@ class TeleportationServiceBukkit(private val playerAttributeService: PlayerAttri
             for (z in -1..1) {
                 val block = location.world.getBlockAt(location.blockX + x, location.blockY - 2, location.blockZ + z)
 
-                if (block.type in configService.getPlatformReplaceBlocks().map { it -> Material.valueOf(it) }) {
+                if (block.type in configService.getPlatformReplaceBlocks().mapNotNull { it ->
+                        runCatching { Material.valueOf(it) }.getOrNull() }) {
                     block.breakNaturally()
-                    block.type = Material.COBBLESTONE // Replace with the desired material
+                    block.type = Material.COBBLESTONE
                 }
             }
         }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpSkinsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpSkinsMenu.kt
@@ -57,7 +57,7 @@ class WarpSkinsMenu(private val player: Player, private val menuNavigator: MenuN
     }
 
     private fun displayBlockList(gui: ChestGui) {
-        val blocks = getAllWarpSkins.execute().map { Material.valueOf(it) }
+        val blocks = getAllWarpSkins.execute().mapNotNull { it -> runCatching { Material.valueOf(it) }.getOrNull() }
 
         val blockListPane = OutlinePane(2, 0, 7, 3)
         for (block in blocks) {


### PR DESCRIPTION
The default configuration file makes use of materials that do not exist in previous versions of Minecraft. This causes errors when trying to use the default config with an older but theoretically supported version. This fix also means that if the administrator inputs incorrect material names, it won't outright break and falls back to either skipping or using default materials when required.