### PR TITLE
Fix cost type and item being invalid, fall back to default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.1]
+
+### Fixed
+- Invalid cost type in the config. Falls back to ITEM if set to an invalid type.
+
 ## [0.3.0]
 
 ### Added

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
@@ -15,7 +15,9 @@ class ConfigServiceBukkit(private val configFile: FileConfiguration): ConfigServ
     }
 
     override fun getTeleportCostType(): CostType {
-        return CostType.valueOf(configFile.getString("teleport_cost_type", "ITEM").toString())
+        return runCatching {
+            CostType.valueOf(configFile.getString("teleport_cost_type", "ITEM").toString())
+        }.getOrDefault(CostType.ITEM)
     }
 
     override fun getTeleportCostItem(): String {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/teleportation/TeleportationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/teleportation/TeleportationServiceBukkit.kt
@@ -141,8 +141,16 @@ class TeleportationServiceBukkit(private val playerAttributeService: PlayerAttri
 
     private fun hasCost(player: Player): Boolean {
         val teleportCost = playerAttributeService.getTeleportCost(player.uniqueId)
+
         return when (configService.getTeleportCostType()) {
-            CostType.ITEM -> hasEnoughItems(player, Material.valueOf(configService.getTeleportCostItem()), teleportCost)
+            CostType.ITEM -> {
+                val material = try {
+                    Material.valueOf(configService.getTeleportCostItem())
+                } catch (_: IllegalArgumentException) {
+                    Material.ENDER_PEARL
+                }
+                hasEnoughItems(player, material, teleportCost)
+            }
             CostType.MONEY -> hasEnoughMoney(player, teleportCost)
             CostType.XP -> hasEnoughXp(player, teleportCost)
         }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/teleportation/TeleportationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/teleportation/TeleportationServiceBukkit.kt
@@ -12,13 +12,9 @@ import dev.mizarc.waystonewarps.domain.whitelist.WhitelistRepository
 import dev.mizarc.waystonewarps.infrastructure.mappers.toLocation
 import net.milkbowl.vault.economy.Economy
 import org.bukkit.Bukkit
-import org.bukkit.Color
 import org.bukkit.Location
 import org.bukkit.Material
-import org.bukkit.Particle
-import org.bukkit.Particle.DustOptions
 import org.bukkit.entity.Player
-import org.bukkit.plugin.Plugin
 import org.bukkit.potion.PotionEffect
 import org.bukkit.potion.PotionEffectType
 import java.util.UUID
@@ -159,7 +155,14 @@ class TeleportationServiceBukkit(private val playerAttributeService: PlayerAttri
     private fun deductCost(player: Player) {
         val teleportCost = playerAttributeService.getTeleportCost(player.uniqueId)
         when (configService.getTeleportCostType()) {
-            CostType.ITEM -> removeItems(player, Material.valueOf(configService.getTeleportCostItem()), teleportCost)
+            CostType.ITEM -> {
+                val material = try {
+                    Material.valueOf(configService.getTeleportCostItem())
+                } catch (_: IllegalArgumentException) {
+                    Material.ENDER_PEARL
+                }
+                removeItems(player, material, teleportCost)
+            }
             CostType.MONEY -> subtractMoney(player, teleportCost)
             CostType.XP -> subtractXp(player, teleportCost)
         }


### PR DESCRIPTION
What it says on the tin. If the cost type is invalid, it falls back to ITEM. If the item material is invalid, it falls back to ENDER_PEARL.