### PR TITLE
Fixed unable to teleport to your own warp when locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 - Warp owner unable to teleport to their own warp when locked.
+- Incorrect message when teleport is cancelled due to movement.
 
 ## [0.3.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.3]
+
+### Fixed
+- Warp owner unable to teleport to their own warp when locked.
+
 ## [0.3.2]
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.3.2"
+version = "0.3.3"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/teleport/TeleportPlayer.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/teleport/TeleportPlayer.kt
@@ -45,7 +45,7 @@ class TeleportPlayer(private val teleportationService: TeleportationService,
                     playerParticleService.removeParticles(playerId)
                 },
                 onCanceled = {
-                    onInsufficientFunds()
+                    onCanceled()
                     playerParticleService.removeParticles(playerId)
                 },
                 onWorldNotFound = {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -14,7 +14,6 @@ import dev.mizarc.waystonewarps.application.actions.whitelist.GetWhitelistedPlay
 import dev.mizarc.waystonewarps.domain.warps.Warp
 import dev.mizarc.waystonewarps.interaction.menus.Menu
 import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
-import dev.mizarc.waystonewarps.interaction.menus.management.PlayerSearchMenu
 import dev.mizarc.waystonewarps.interaction.messaging.AccentColourPalette
 import dev.mizarc.waystonewarps.interaction.messaging.PrimaryColourPalette
 import dev.mizarc.waystonewarps.interaction.models.toViewModel
@@ -25,8 +24,6 @@ import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
 import me.xdrop.fuzzywuzzy.FuzzySearch
 import net.kyori.adventure.text.Component
-import org.bukkit.Bukkit
-import org.bukkit.OfflinePlayer
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -228,7 +225,8 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             customLore.add(0, "§6${warpModel.player.name}")
 
             var guiWarpItem: GuiItem
-            if (warp.isLocked && !getWhitelistedPlayers.execute(warp.id).contains(player.uniqueId)) {
+            if (warp.isLocked && !getWhitelistedPlayers.execute(warp.id).contains(player.uniqueId)
+                    && player.uniqueId != warp.playerId) {
                 customLore.add(2, "§cLOCKED")
                 val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(customLore)
                 guiWarpItem = GuiItem(warpItem) { guiEvent ->

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: WaystoneWarps
-version: 0.3.2
+version: 0.3.3
 api-version: '1.21'
 main: dev.mizarc.waystonewarps.WaystoneWarps


### PR DESCRIPTION
Warp owners should never be locked out of their own warp. An additional check has been added to ensure warp owners are excluded from the lock.

Additionally, a message has been fixed for teleport cancel due to movement, with it triggering the insufficient funds output instead.