### PR TITLE
Fixed waystone creation checks failing on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.3]
+
+### Fixed
+- Waystone creation not checking if the top block is a Lodestone, resulting in the menu popping up for any block on top of a valid base block.
+- Waystone creation with base bypassing removal of config specified base block
+
 ## [0.3.2]
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.3.2"
+version = "0.3.3"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
@@ -37,6 +37,7 @@ class ConfigServiceBukkit(private val configFile: FileConfiguration): ConfigServ
     }
 
     override fun getStructureBlocks(blockType: String): List<String> {
+        if (blockType !in getAllSkinTypes()) return emptyList()
         return configFile.getStringList("waystone_skins.$blockType")
     }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneInteractListener.kt
@@ -99,7 +99,7 @@ class WaystoneInteractListener(private val configService: ConfigService): Listen
 
         // Check if valid warp base to create warp
         val baseBlock = clickedBlock.getRelative(BlockFace.DOWN)
-        if (isValidWarpBase.execute(baseBlock.type.toString())) {
+        if (isValidWarpBase.execute(baseBlock.type.toString()) && clickedBlock.type == Material.LODESTONE) {
             player.swingMainHand()
             event.isCancelled = true
             menuNavigator.openMenu(WarpNamingMenu(player, menuNavigator, clickedBlock.location))

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: WaystoneWarps
-version: 0.3.2
+version: 0.3.3
 api-version: '1.21'
 main: dev.mizarc.waystonewarps.WaystoneWarps


### PR DESCRIPTION
This solves the issue of both the waystone creation process ignoring the top block and only checking for the base block, as well as the base block being able to ignore when the block is removed from the config.