### PR TITLE
Added support for versions 1.21.7 to 1.21.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ hs_err_pid*
 ### Gradle ###
 .gradle
 build/
+local.properties
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/WaystoneWarps.main.iml" filepath="$PROJECT_DIR$/.idea/modules/WaystoneWarps.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/WaystoneWarps.test.iml" filepath="$PROJECT_DIR$/.idea/modules/WaystoneWarps.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/dev.mizarc.WaystoneWarps.main.iml" filepath="$PROJECT_DIR$/.idea/modules/dev.mizarc.WaystoneWarps.main.iml" />
     </modules>
   </component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,29 @@
+import java.util.Properties
+
 plugins {
     kotlin("jvm") version "2.0.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
+val localProperties = Properties()
+val localPropertiesFile = rootProject.file("local.properties")
+
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.inputStream().use { inputStream ->
+        localProperties.load(inputStream)
+    }
+}
+
+fun getProperty(name: String): String {
+    val localValue = localProperties.getProperty(name)
+    if (localValue != null) {
+        return localValue
+    }
+    return providers.gradleProperty(name).getOrElse("")
+}
+
 group = "dev.mizarc"
-version = "0.3.4"
+version = "0.3.5"
 
 repositories {
     mavenLocal()
@@ -35,7 +54,7 @@ dependencies {
     implementation("co.aikar:idb-core:1.0.0-SNAPSHOT")
     implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
     implementation("com.zaxxer:HikariCP:5.0.1")
-    implementation("com.github.stefvanschie.inventoryframework:IF:0.11.1")
+    implementation("com.github.mizarc:IF:0.11.4-d")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
     implementation("me.xdrop:fuzzywuzzy:1.3.1")
 }
@@ -50,4 +69,13 @@ tasks.test {
 
 tasks.shadowJar {
     archiveClassifier = null
+}
+
+tasks.register<Copy>("deploy") {
+    dependsOn(tasks.shadowJar)
+    from(layout.buildDirectory.dir("libs"))
+    println("Target deployment path: ${getProperty("plugin.server.path")}")
+    into(getProperty("plugin.server.path"))
+    rename { fileName -> "${rootProject.name}-${version}.jar" }
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+plugin.server.path=/path/to/minecraft_server/

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: WaystoneWarps
-version: 0.3.4
+version: 0.3.5
 api-version: '1.21'
 main: dev.mizarc.waystonewarps.WaystoneWarps


### PR DESCRIPTION
This just required a simple dependency update. From now on I'm going to be handling my own Inventory Framework fork instead of relying on a third party as it has become a large bottleneck for updates.