### PR TITLE
Remove waystone display structure on plugin disable

### DIFF
--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -22,10 +22,11 @@ import dev.mizarc.waystonewarps.application.actions.management.UpdateWarpName
 import dev.mizarc.waystonewarps.application.actions.management.UpdateWarpSkin
 import dev.mizarc.waystonewarps.application.actions.whitelist.ToggleWhitelist
 import dev.mizarc.waystonewarps.application.actions.whitelist.GetWhitelistedPlayers
+import dev.mizarc.waystonewarps.application.actions.world.AddAllDisplays
 import dev.mizarc.waystonewarps.application.actions.world.IsPositionInTeleportZone
 import dev.mizarc.waystonewarps.application.actions.world.IsValidWarpBase
 import dev.mizarc.waystonewarps.application.actions.world.MoveWarp
-import dev.mizarc.waystonewarps.application.actions.world.RefreshAllDisplays
+import dev.mizarc.waystonewarps.application.actions.world.RemoveAllDisplays
 import dev.mizarc.waystonewarps.application.services.*
 import dev.mizarc.waystonewarps.application.services.scheduling.SchedulerService
 import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
@@ -97,7 +98,7 @@ class WaystoneWarps: JavaPlugin() {
         registerDependencies()
         registerCommands()
         registerEvents()
-        RefreshAllDisplays(warpRepository, structureBuilderService, hologramService).execute()
+        AddAllDisplays(warpRepository, structureBuilderService, hologramService).execute()
 
         for (warp in warpRepository.getAll()) {
             structureParticleService.spawnParticles(warp)
@@ -107,6 +108,7 @@ class WaystoneWarps: JavaPlugin() {
     }
 
     override fun onDisable() {
+        RemoveAllDisplays(warpRepository, structureBuilderService, hologramService).execute()
         logger.info("WaystoneWarps has been Disabled")
     }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/AddAllDisplays.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/AddAllDisplays.kt
@@ -1,0 +1,17 @@
+package dev.mizarc.waystonewarps.application.actions.world
+
+import dev.mizarc.waystonewarps.application.services.HologramService
+import dev.mizarc.waystonewarps.application.services.StructureBuilderService
+import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+
+class AddAllDisplays(private val warpRepository: WarpRepository,
+                         private val structureBuilderService: StructureBuilderService,
+                         private val hologramService: HologramService) {
+    fun execute() {
+        val warps = warpRepository.getAll()
+        for (warp in warps) {
+            structureBuilderService.spawnStructure(warp)
+            hologramService.spawnHologram(warp)
+        }
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/RemoveAllDisplays.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/RemoveAllDisplays.kt
@@ -4,16 +4,14 @@ import dev.mizarc.waystonewarps.application.services.HologramService
 import dev.mizarc.waystonewarps.application.services.StructureBuilderService
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 
-class RefreshAllDisplays(private val warpRepository: WarpRepository,
+class RemoveAllDisplays(private val warpRepository: WarpRepository,
                          private val structureBuilderService: StructureBuilderService,
                          private val hologramService: HologramService) {
     fun execute() {
         val warps = warpRepository.getAll()
         for (warp in warps) {
-            structureBuilderService.destroyStructure(warp)
-            structureBuilderService.spawnStructure(warp)
+            structureBuilderService.revertStructure(warp)
             hologramService.removeHologram(warp)
-            hologramService.spawnHologram(warp)
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/StructureBuilderServiceBukkit.kt
@@ -44,6 +44,7 @@ class StructureBuilderServiceBukkit(private val plugin: Plugin, private val conf
     override fun revertStructure(warp: Warp) {
         val world = Bukkit.getWorld(warp.worldId) ?: return
         val location = warp.position.toLocation(world)
+        world.getBlockAt(location.blockX, location.blockY, location.blockZ).type = Material.LODESTONE
         world.getBlockAt(location.blockX, location.blockY - 1, location.blockZ).type = Material.valueOf(warp.block)
         removeBlockDisplay(warp, world)
     }


### PR DESCRIPTION
To resolve the issue of waystone structures remaining in the world if the plugin is removed from the server, the waystone structures are now removed on disable, and recreated on enable. This is as opposed to the existing behaviour where they are simply refreshed on enabling.