### PR TITLE
Fix config not being read on first launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 - Support for Minecraft 1.21.11.
 
+### Fixed
+- Config not being read on the first launch, required restart before the plugin could actually let you do anything.
+
 ## [0.3.5]
 
 ### Added

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -122,6 +122,7 @@ class WaystoneWarps: JavaPlugin() {
 
     private fun initialiseConfig() {
         saveDefaultConfig()
+        reloadConfig()
         getResource("config.yml")?.use { defaultConfigStream ->
             val sampleConfigFile = File(dataFolder, "sample-config.yml")
             try {


### PR DESCRIPTION
The first launch of the server without a config file would not be functional, as the config was not being read. This fix just refreshes the config after saving for the first time.