### PR TITLE
Support additional metadata for waystone icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Support for Minecraft 1.21.11.
 - Waystone creation is covered by protections that protect against block placing.
 - Icons for waystones now support metadata including custom model data, armour dyes, trims, firework colours, potion types.
+- Automatic database schema migrations on startup, including schema version tracking.
 
 ### Changed
 - Menu buttons are now gold with a grey description for standardisation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 - Support for Minecraft 1.21.11.
 - Waystone creation is covered by protections that protect against block placing.
+- Icons for waystones now support metadata including custom model data, armour dyes, trims, firework colours, potion types.
+
+### Changed
+- Menu buttons are now gold with a grey description for standardisation.
 
 ### Fixed
 - Config not being read on the first launch, required restart before the plugin could actually let you do anything.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import java.util.Properties
 plugins {
     kotlin("jvm") version "2.0.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"
+    kotlin("plugin.serialization") version "2.3.0"
 }
 
 val localProperties = Properties()
@@ -48,6 +49,7 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     shadow("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.insert-koin:koin-core:4.0.2")

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -38,7 +38,8 @@ import org.bukkit.plugin.java.JavaPlugin
 import dev.mizarc.waystonewarps.interaction.commands.WarpMenuCommand
 import dev.mizarc.waystonewarps.infrastructure.persistence.discoveries.DiscoveryRepositorySQLite
 import dev.mizarc.waystonewarps.infrastructure.persistence.playerstate.PlayerStateRepositoryMemory
-import dev.mizarc.waystonewarps.infrastructure.persistence.migrations.Migration1_CreateInitialTables
+import dev.mizarc.waystonewarps.infrastructure.persistence.migrations.Migration0_CreateInitialTables
+import dev.mizarc.waystonewarps.infrastructure.persistence.migrations.Migration1_AddWarpIconMeta
 import dev.mizarc.waystonewarps.infrastructure.persistence.migrations.SchemaMigrator
 import dev.mizarc.waystonewarps.infrastructure.persistence.storage.SQLiteStorage
 import dev.mizarc.waystonewarps.infrastructure.persistence.storage.Storage
@@ -93,7 +94,8 @@ class WaystoneWarps: JavaPlugin() {
             SchemaMigrator(
                 db = storage.connection,
                 migrations = listOf(
-                    Migration1_CreateInitialTables(),
+                    Migration0_CreateInitialTables(),
+                    Migration1_AddWarpIconMeta(),
                 ),
             ).migrateToLatest()
         } catch (ex: Exception) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -38,6 +38,8 @@ import org.bukkit.plugin.java.JavaPlugin
 import dev.mizarc.waystonewarps.interaction.commands.WarpMenuCommand
 import dev.mizarc.waystonewarps.infrastructure.persistence.discoveries.DiscoveryRepositorySQLite
 import dev.mizarc.waystonewarps.infrastructure.persistence.playerstate.PlayerStateRepositoryMemory
+import dev.mizarc.waystonewarps.infrastructure.persistence.migrations.Migration1_CreateInitialTables
+import dev.mizarc.waystonewarps.infrastructure.persistence.migrations.SchemaMigrator
 import dev.mizarc.waystonewarps.infrastructure.persistence.storage.SQLiteStorage
 import dev.mizarc.waystonewarps.infrastructure.persistence.storage.Storage
 import dev.mizarc.waystonewarps.infrastructure.persistence.warps.WarpRepositorySQLite
@@ -86,6 +88,20 @@ class WaystoneWarps: JavaPlugin() {
 
         // Get storage type
         storage = SQLiteStorage(this.dataFolder)
+
+        try {
+            SchemaMigrator(
+                db = storage.connection,
+                migrations = listOf(
+                    Migration1_CreateInitialTables(),
+                ),
+            ).migrateToLatest()
+        } catch (ex: Exception) {
+            logger.severe("Failed to migrate database: ${ex.message}")
+            ex.printStackTrace()
+            server.pluginManager.disablePlugin(this)
+            return
+        }
 
         // Get command manager
         commandManager = PaperCommandManager(this)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpIcon.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpIcon.kt
@@ -1,12 +1,14 @@
 package dev.mizarc.waystonewarps.application.actions.management
 
+import CustomModelData
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import java.util.*
 
 class UpdateWarpIcon(private val warpRepository: WarpRepository) {
-    fun execute(warpId: UUID, materialName: String): Result<Unit> {
+    fun execute(warpId: UUID, materialName: String, iconMeta: CustomModelData = CustomModelData()): Result<Unit> {
         val warp = warpRepository.getById(warpId) ?: return Result.failure(Exception("Warp not found"))
         warp.icon = materialName
+        warp.iconMeta = iconMeta
         warpRepository.update(warp)
         return Result.success(Unit)
     }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpIcon.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpIcon.kt
@@ -1,11 +1,11 @@
 package dev.mizarc.waystonewarps.application.actions.management
 
-import CustomModelData
+import IconMeta
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import java.util.*
 
 class UpdateWarpIcon(private val warpRepository: WarpRepository) {
-    fun execute(warpId: UUID, materialName: String, iconMeta: CustomModelData = CustomModelData()): Result<Unit> {
+    fun execute(warpId: UUID, materialName: String, iconMeta: IconMeta = IconMeta()): Result<Unit> {
         val warp = warpRepository.getById(warpId) ?: return Result.failure(Exception("Warp not found"))
         warp.icon = materialName
         warp.iconMeta = iconMeta

--- a/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/IconMeta.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/IconMeta.kt
@@ -1,0 +1,10 @@
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IconMeta(
+    val schemaVersion: Int = 1,
+    val strings: List<String> = emptyList(),
+    val floats: List<Float> = emptyList(),
+    val flags: List<Boolean> = emptyList(),
+    val colorsArgb: List<Int> = emptyList()
+)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/IconMeta.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/IconMeta.kt
@@ -12,5 +12,12 @@ data class IconMeta(
     val flags: List<Boolean> = emptyList(),
     val colorsArgb: List<Int> = emptyList(),
     val potionTypeKey: String? = null,
-    val leatherColorRgb: Int? = null
+    val leatherColorRgb: Int? = null,
+    val trimPatternKey: String? = null,
+    val trimMaterialKey: String? = null,
+    val bannerBaseColor: String? = null,
+    val bannerPatterns: List<String> = emptyList(),
+    val skullTextureValue: String? = null,
+    val skullTextureSignature: String? = null,
+    val fireworkStarColorRgb: Int? = null
 )

--- a/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/IconMeta.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/IconMeta.kt
@@ -1,10 +1,16 @@
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class IconMeta(
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     val schemaVersion: Int = 1,
     val strings: List<String> = emptyList(),
     val floats: List<Float> = emptyList(),
     val flags: List<Boolean> = emptyList(),
-    val colorsArgb: List<Int> = emptyList()
+    val colorsArgb: List<Int> = emptyList(),
+    val potionTypeKey: String? = null,
+    val leatherColorRgb: Int? = null
 )

--- a/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/Warp.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/Warp.kt
@@ -1,8 +1,7 @@
 package dev.mizarc.waystonewarps.domain.warps
 
-import CustomModelData
+import IconMeta
 import dev.mizarc.waystonewarps.domain.positioning.Position3D
-import org.bukkit.Material
 import java.time.Instant
 import java.util.*
 import kotlin.concurrent.thread
@@ -17,7 +16,7 @@ import kotlin.concurrent.thread
  * @property icon The name of the material to use as an icon.
  */
 class Warp(val id: UUID, val playerId: UUID, val creationTime: Instant, var name: String, var worldId: UUID,
-           var position: Position3D, var icon: String, var iconMeta: CustomModelData, var block: String, var isLocked: Boolean) {
+           var position: Position3D, var icon: String, var iconMeta: IconMeta, var block: String, var isLocked: Boolean) {
     var breakCount = 3
 
     private val defaultBreakCount = 3
@@ -33,7 +32,7 @@ class Warp(val id: UUID, val playerId: UUID, val creationTime: Instant, var name
      * @param block The base block being used for the physical appearance.
      */
     constructor(worldId: UUID, playerId: UUID, position: Position3D, name: String, block: String) : this(
-        UUID.randomUUID(), playerId, Instant.now(), name, worldId, position, "LODESTONE", CustomModelData(), block, false)
+        UUID.randomUUID(), playerId, Instant.now(), name, worldId, position, "LODESTONE", IconMeta(), block, false)
 
     /**
      * Resets the break count after a set period of time.

--- a/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/Warp.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/Warp.kt
@@ -1,5 +1,6 @@
 package dev.mizarc.waystonewarps.domain.warps
 
+import CustomModelData
 import dev.mizarc.waystonewarps.domain.positioning.Position3D
 import org.bukkit.Material
 import java.time.Instant
@@ -16,7 +17,7 @@ import kotlin.concurrent.thread
  * @property icon The name of the material to use as an icon.
  */
 class Warp(val id: UUID, val playerId: UUID, val creationTime: Instant, var name: String, var worldId: UUID,
-           var position: Position3D, var icon: String, var block: String, var isLocked: Boolean) {
+           var position: Position3D, var icon: String, var iconMeta: CustomModelData, var block: String, var isLocked: Boolean) {
     var breakCount = 3
 
     private val defaultBreakCount = 3
@@ -32,7 +33,7 @@ class Warp(val id: UUID, val playerId: UUID, val creationTime: Instant, var name
      * @param block The base block being used for the physical appearance.
      */
     constructor(worldId: UUID, playerId: UUID, position: Position3D, name: String, block: String) : this(
-        UUID.randomUUID(), playerId, Instant.now(), name, worldId, position, "LODESTONE", block, false)
+        UUID.randomUUID(), playerId, Instant.now(), name, worldId, position, "LODESTONE", CustomModelData(), block, false)
 
     /**
      * Resets the break count after a set period of time.

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/discoveries/DiscoveryRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/discoveries/DiscoveryRepositorySQLite.kt
@@ -12,7 +12,6 @@ class DiscoveryRepositorySQLite(private val storage: Storage<Database>): Discove
     private val discoveries: MutableMap<UUID, MutableSet<Discovery>> = mutableMapOf()
 
     init {
-        createTable()
         preload()
     }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/Migration.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/Migration.kt
@@ -1,0 +1,10 @@
+package dev.mizarc.waystonewarps.infrastructure.persistence.migrations
+
+import co.aikar.idb.Database
+
+interface Migration {
+    val fromVersion: Int
+    val toVersion: Int
+
+    fun migrate(db: Database)
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/Migration0_CreateInitialTables.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/Migration0_CreateInitialTables.kt
@@ -2,15 +2,15 @@ package dev.mizarc.waystonewarps.infrastructure.persistence.migrations
 
 import co.aikar.idb.Database
 
-class Migration1_CreateInitialTables : Migration {
-    override val fromVersion: Int = 0
-    override val toVersion: Int = 1
+class Migration0_CreateInitialTables : Migration {
+    override val fromVersion: Int = -1
+    override val toVersion: Int = 0
 
     override fun migrate(db: Database) {
         db.executeUpdate(
             "CREATE TABLE IF NOT EXISTS warps (id TEXT NOT NULL, " +
                 "playerId TEXT NOT NULL, creationTime TEXT NOT NULL, name TEXT, worldId TEXT NOT NULL, " +
-                "positionX INTEGER NOT NULL, positionY INTEGER NOT NULL, positionZ INTEGER NOT NULL, icon TEXT, iconMeta TEXT," +
+                "positionX INTEGER NOT NULL, positionY INTEGER NOT NULL, positionZ INTEGER NOT NULL, icon TEXT," +
                 "block TEXT, isLocked INTEGER);"
         )
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/Migration1_AddWarpIconMeta.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/Migration1_AddWarpIconMeta.kt
@@ -1,0 +1,14 @@
+package dev.mizarc.waystonewarps.infrastructure.persistence.migrations
+
+import co.aikar.idb.Database
+
+class Migration1_AddWarpIconMeta : Migration {
+    override val fromVersion: Int = 0
+    override val toVersion: Int = 1
+
+    override fun migrate(db: Database) {
+        runCatching {
+            db.executeUpdate("ALTER TABLE warps ADD COLUMN iconMeta TEXT;")
+        }
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/Migration1_CreateInitialTables.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/Migration1_CreateInitialTables.kt
@@ -1,0 +1,32 @@
+package dev.mizarc.waystonewarps.infrastructure.persistence.migrations
+
+import co.aikar.idb.Database
+
+class Migration1_CreateInitialTables : Migration {
+    override val fromVersion: Int = 0
+    override val toVersion: Int = 1
+
+    override fun migrate(db: Database) {
+        db.executeUpdate(
+            "CREATE TABLE IF NOT EXISTS warps (id TEXT NOT NULL, " +
+                "playerId TEXT NOT NULL, creationTime TEXT NOT NULL, name TEXT, worldId TEXT NOT NULL, " +
+                "positionX INTEGER NOT NULL, positionY INTEGER NOT NULL, positionZ INTEGER NOT NULL, icon TEXT, iconMeta TEXT," +
+                "block TEXT, isLocked INTEGER);"
+        )
+
+        db.executeUpdate(
+            "CREATE TABLE IF NOT EXISTS discoveries (warpId TEXT, " +
+                "playerId TEXT, discoveredTime TEXT, lastVisitedTime TEXT, isFavourite INTEGER," +
+                "PRIMARY KEY(warpId, playerId));"
+        )
+
+        db.executeUpdate(
+            "CREATE TABLE IF NOT EXISTS whitelist (" +
+                "warpId TEXT NOT NULL," +
+                "playerId TEXT NOT NULL," +
+                "creationTime TEXT NOT NULL," +
+                "PRIMARY KEY (warpId, playerId)" +
+                ");"
+        )
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/SchemaMigrator.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/migrations/SchemaMigrator.kt
@@ -1,0 +1,73 @@
+package dev.mizarc.waystonewarps.infrastructure.persistence.migrations
+
+import co.aikar.idb.Database
+
+class SchemaMigrator(
+    private val db: Database,
+    private val migrations: List<Migration>,
+) {
+    fun migrateToLatest() {
+        ensureSchemaVersionTable()
+
+        val currentVersion = getCurrentVersion()
+        val latestVersion = migrations.maxOfOrNull { it.toVersion } ?: 0
+
+        if (currentVersion > latestVersion) {
+            throw IllegalStateException("Database schema version $currentVersion is newer than supported version $latestVersion")
+        }
+
+        val migrationByFromVersion = migrations.associateBy { it.fromVersion }
+        val toVersionDuplicates = migrations.groupBy { it.toVersion }.filterValues { it.size > 1 }
+        if (toVersionDuplicates.isNotEmpty()) {
+            throw IllegalStateException("Duplicate migration toVersion values: ${toVersionDuplicates.keys.sorted()}")
+        }
+
+        var version = currentVersion
+        while (version < latestVersion) {
+            val migration = migrationByFromVersion[version]
+                ?: throw IllegalStateException("Missing migration fromVersion=$version")
+
+            if (migration.toVersion != version + 1) {
+                throw IllegalStateException("Invalid migration chain: ${migration.fromVersion} -> ${migration.toVersion}")
+            }
+
+            runInTransaction {
+                migration.migrate(db)
+                setCurrentVersion(migration.toVersion)
+            }
+
+            version = migration.toVersion
+        }
+    }
+
+    private fun ensureSchemaVersionTable() {
+        db.executeUpdate(
+            "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);"
+        )
+
+        val row = db.getResults("SELECT version FROM schema_version LIMIT 1;").firstOrNull()
+        if (row == null) {
+            db.executeUpdate("INSERT INTO schema_version (version) VALUES (0);")
+        }
+    }
+
+    private fun getCurrentVersion(): Int {
+        val row = db.getResults("SELECT version FROM schema_version LIMIT 1;").firstOrNull()
+        return row?.getInt("version") ?: 0
+    }
+
+    private fun setCurrentVersion(version: Int) {
+        db.executeUpdate("UPDATE schema_version SET version=?;", version)
+    }
+
+    private inline fun runInTransaction(block: () -> Unit) {
+        db.executeUpdate("BEGIN IMMEDIATE;")
+        try {
+            block()
+            db.executeUpdate("COMMIT;")
+        } catch (ex: Exception) {
+            runCatching { db.executeUpdate("ROLLBACK;") }
+            throw ex
+        }
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
@@ -15,7 +15,7 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
 
     private val iconMetaJson = Json {
         ignoreUnknownKeys = true
-        encodeDefaults = true
+        encodeDefaults = false
         explicitNulls = false
     }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
@@ -13,6 +13,12 @@ import java.util.*
 class WarpRepositorySQLite(private val storage: Storage<Database>): WarpRepository {
     private val warps: MutableMap<UUID, Warp> = mutableMapOf()
 
+    private val iconMetaJson = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
     init {
         createTable()
         preload()
@@ -76,10 +82,14 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
         for (result in results) {
             val iconMeta = runCatching {
                 val raw = result.getString("iconMeta")
+                println(raw)
                 if (raw.isNullOrBlank()) IconMeta() else iconMetaJson.decodeFromString<IconMeta>(raw)
-            }.getOrElse {
+            }.getOrElse { ex ->
+                ex.printStackTrace()
                 IconMeta()
             }
+            println("preloading")
+            println(iconMeta)
 
             warps[UUID.fromString(result.getString("id"))] = Warp(
                 UUID.fromString(result.getString("id")),
@@ -96,11 +106,5 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
                 result.getString("block"),
                 result.getInt("isLocked") != 0)
         }
-    }
-
-    private val iconMetaJson = Json {
-        ignoreUnknownKeys = true
-        encodeDefaults = true
-        explicitNulls = false
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
@@ -1,10 +1,12 @@
 package dev.mizarc.waystonewarps.infrastructure.persistence.warps
 
+import CustomModelData
 import co.aikar.idb.Database
 import dev.mizarc.waystonewarps.domain.positioning.Position3D
 import dev.mizarc.waystonewarps.domain.warps.Warp
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import dev.mizarc.waystonewarps.infrastructure.persistence.storage.Storage
+import kotlinx.serialization.json.Json
 import java.time.Instant
 import java.util.*
 
@@ -38,19 +40,21 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
 
     override fun add(warp: Warp) {
         warps[warp.id] = warp
+        val iconMetaJsonString = iconMetaJson.encodeToString(warp.iconMeta)
         storage.connection.executeInsert("INSERT INTO warps (id, playerId, creationTime, name, worldId, " +
-                "positionX, positionY, positionZ, icon, block, isLocked) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+                "positionX, positionY, positionZ, icon, iconMeta, block, isLocked) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
             warp.id, warp.playerId, warp.creationTime, warp.name, warp.worldId,
-            warp.position.x, warp.position.y, warp.position.z, warp.icon, warp.block, warp.isLocked)
+            warp.position.x, warp.position.y, warp.position.z, warp.icon, iconMetaJsonString, warp.block, warp.isLocked)
     }
 
     override fun update(warp: Warp) {
         warps.remove(warp.id)
         warps[warp.id] = warp
+        val iconMetaJsonString = iconMetaJson.encodeToString(warp.iconMeta)
         storage.connection.executeUpdate("UPDATE warps SET playerId=?, creationTime=?, name=?, worldId=?, " +
-                "positionX=?, positionY=?, positionZ=?, icon=?, block=?, isLocked=? WHERE id=?",
+                "positionX=?, positionY=?, positionZ=?, icon=?, iconMeta=?, block=?, isLocked=? WHERE id=?",
             warp.playerId, warp.creationTime, warp.name, warp.worldId, warp.position.x, warp.position.y,
-            warp.position.z, warp.icon, warp.block, warp.isLocked, warp.id)
+            warp.position.z, warp.icon, iconMetaJsonString, warp.block, warp.isLocked, warp.id)
         return
     }
 
@@ -62,13 +66,21 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
     private fun createTable() {
         storage.connection.executeUpdate("CREATE TABLE IF NOT EXISTS warps (id TEXT NOT NULL, " +
                 "playerId TEXT NOT NULL, creationTime TEXT NOT NULL, name TEXT, worldId TEXT NOT NULL, " +
-                "positionX INTEGER NOT NULL, positionY INTEGER NOT NULL, positionZ INTEGER NOT NULL, icon TEXT, " +
+                "positionX INTEGER NOT NULL, positionY INTEGER NOT NULL, positionZ INTEGER NOT NULL, icon TEXT, iconMeta TEXT," +
                 "block TEXT, isLocked INTEGER);")
     }
 
     private fun preload() {
         val results = storage.connection.getResults("SELECT * FROM warps;")
+
         for (result in results) {
+            val iconMeta = runCatching {
+                val raw = result.getString("iconMeta")
+                if (raw.isNullOrBlank()) CustomModelData() else iconMetaJson.decodeFromString<CustomModelData>(raw)
+            }.getOrElse {
+                CustomModelData()
+            }
+
             warps[UUID.fromString(result.getString("id"))] = Warp(
                 UUID.fromString(result.getString("id")),
                 UUID.fromString(result.getString("playerId")),
@@ -80,8 +92,15 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
                     result.getInt("positionY"),
                     result.getInt("positionZ")),
                 result.getString("icon"),
+                iconMeta,
                 result.getString("block"),
                 result.getInt("isLocked") != 0)
         }
+    }
+
+    private val iconMetaJson = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
@@ -1,6 +1,6 @@
 package dev.mizarc.waystonewarps.infrastructure.persistence.warps
 
-import CustomModelData
+import IconMeta
 import co.aikar.idb.Database
 import dev.mizarc.waystonewarps.domain.positioning.Position3D
 import dev.mizarc.waystonewarps.domain.warps.Warp
@@ -76,9 +76,9 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
         for (result in results) {
             val iconMeta = runCatching {
                 val raw = result.getString("iconMeta")
-                if (raw.isNullOrBlank()) CustomModelData() else iconMetaJson.decodeFromString<CustomModelData>(raw)
+                if (raw.isNullOrBlank()) IconMeta() else iconMetaJson.decodeFromString<IconMeta>(raw)
             }.getOrElse {
-                CustomModelData()
+                IconMeta()
             }
 
             warps[UUID.fromString(result.getString("id"))] = Warp(

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
@@ -20,7 +20,6 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
     }
 
     init {
-        createTable()
         preload()
     }
 
@@ -67,13 +66,6 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
     override fun remove(id: UUID) {
         warps.remove(id)
         storage.connection.executeUpdate("DELETE FROM warps WHERE id=?", id)
-    }
-
-    private fun createTable() {
-        storage.connection.executeUpdate("CREATE TABLE IF NOT EXISTS warps (id TEXT NOT NULL, " +
-                "playerId TEXT NOT NULL, creationTime TEXT NOT NULL, name TEXT, worldId TEXT NOT NULL, " +
-                "positionX INTEGER NOT NULL, positionY INTEGER NOT NULL, positionZ INTEGER NOT NULL, icon TEXT, iconMeta TEXT," +
-                "block TEXT, isLocked INTEGER);")
     }
 
     private fun preload() {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/whitelist/WhitelistRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/whitelist/WhitelistRepositorySQLite.kt
@@ -11,7 +11,6 @@ class WhitelistRepositorySQLite(private val storage: Storage<Database>): Whiteli
     private val whitelistMap = HashMap<UUID, MutableSet<UUID>>()
 
     init {
-        createTable()
         preload()
     }
 
@@ -49,17 +48,6 @@ class WhitelistRepositorySQLite(private val storage: Storage<Database>): Whiteli
     override fun removeByWarp(warpId: UUID) {
         whitelistMap.remove(warpId)
         storage.connection.executeUpdate("DELETE FROM whitelist WHERE warpId=?", warpId)
-    }
-
-    private fun createTable() {
-        storage.connection.executeUpdate("""
-            CREATE TABLE IF NOT EXISTS whitelist (
-                warpId TEXT NOT NULL,
-                playerId TEXT NOT NULL,
-                creationTime TEXT NOT NULL,
-                PRIMARY KEY (warpId, playerId)
-            );"""
-        )
     }
 
     private fun preload() {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpIconMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpIconMenu.kt
@@ -1,6 +1,6 @@
 package dev.mizarc.waystonewarps.interaction.menus.management
 
-import CustomModelData
+import IconMeta
 import com.github.stefvanschie.inventoryframework.gui.GuiItem
 import com.github.stefvanschie.inventoryframework.gui.type.FurnaceGui
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
@@ -68,14 +68,14 @@ class WarpIconMenu(private val player: Player,
             if (newIcon != null) {
                 val paperCmd = newIcon.getData(DataComponentTypes.CUSTOM_MODEL_DATA)
                 val iconMeta = if (paperCmd != null) {
-                    CustomModelData(
+                    IconMeta(
                         strings = paperCmd.strings(),
                         floats = paperCmd.floats(),
                         flags = paperCmd.flags(),
                         colorsArgb = paperCmd.colors().map { it.asARGB() }
                     )
                 } else {
-                    CustomModelData()
+                    IconMeta()
                 }
                 updateWarpIcon.execute(warp.id, newIcon.type.name, iconMeta)
             }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpIconMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpIconMenu.kt
@@ -14,6 +14,8 @@ import io.papermc.paper.datacomponent.DataComponentTypes
 import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.LeatherArmorMeta
+import org.bukkit.inventory.meta.PotionMeta
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import kotlin.concurrent.thread
@@ -67,16 +69,34 @@ class WarpIconMenu(private val player: Player,
             // Set icon if item in slot
             if (newIcon != null) {
                 val paperCmd = newIcon.getData(DataComponentTypes.CUSTOM_MODEL_DATA)
+                val potionTypeKey = (newIcon.itemMeta as? PotionMeta)
+                    ?.basePotionType
+                    ?.key
+                    ?.toString()
+                println("potionTypeKey:")
+                println(potionTypeKey)
+
+                val leatherColorRgb = (newIcon.itemMeta as? LeatherArmorMeta)
+                    ?.color
+                    ?.asRGB()
+                println("leatherColorRgb:")
+                println(leatherColorRgb)
                 val iconMeta = if (paperCmd != null) {
                     IconMeta(
                         strings = paperCmd.strings(),
                         floats = paperCmd.floats(),
                         flags = paperCmd.flags(),
-                        colorsArgb = paperCmd.colors().map { it.asARGB() }
+                        colorsArgb = paperCmd.colors().map { it.asARGB() },
+                        potionTypeKey = potionTypeKey,
+                        leatherColorRgb = leatherColorRgb
                     )
                 } else {
-                    IconMeta()
+                    IconMeta(
+                        potionTypeKey = potionTypeKey,
+                        leatherColorRgb = leatherColorRgb
+                    )
                 }
+                println(iconMeta)
                 updateWarpIcon.execute(warp.id, newIcon.type.name, iconMeta)
             }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpIconMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpIconMenu.kt
@@ -15,7 +15,6 @@ import io.papermc.paper.datacomponent.DataComponentTypes
 import io.papermc.paper.registry.RegistryAccess
 import io.papermc.paper.registry.RegistryKey
 import org.bukkit.Material
-import org.bukkit.Registry
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ArmorMeta
@@ -32,6 +31,7 @@ class WarpIconMenu(private val player: Player,
                    private val menuNavigator: MenuNavigator, private val warp: Warp): Menu, KoinComponent {
     private val updateWarpIcon: UpdateWarpIcon by inject()
 
+    @Suppress("UnstableApiUsage")
     override fun open() {
         val gui = FurnaceGui("Set Warp Icon")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
@@ -46,7 +46,7 @@ class WarpIconMenu(private val player: Player,
         fuelPane.addItem(guiIconEditorItem, 0, 0)
         gui.fuelComponent.addPane(fuelPane)
 
-        // Allow item to be placed in slot
+        // Allow item to be placed in the slot
         val inputPane = StaticPane(0, 0, 1, 1)
         inputPane.setOnClick {guiEvent ->
             guiEvent.isCancelled = true
@@ -75,7 +75,7 @@ class WarpIconMenu(private val player: Player,
             val newIcon = gui.ingredientComponent.getItem(0, 0)
             val registryAccess = RegistryAccess.registryAccess()
 
-            // Set icon if item in slot
+            // Set icon if the item in slot
             if (newIcon != null) {
                 // Get potion type
                 val potionTypeKey = (newIcon.itemMeta as? PotionMeta)
@@ -83,19 +83,19 @@ class WarpIconMenu(private val player: Player,
                     ?.key
                     ?.toString()
 
-                // Get leather armor color
+                // Get leather armour colour
                 val leatherColorRgb = (newIcon.itemMeta as? LeatherArmorMeta)
                     ?.color
                     ?.asRGB()
 
-                // Get armor trim pattern and material
+                // Get armour trim pattern and material
                 val armorTrim = (newIcon.itemMeta as? ArmorMeta)?.trim
                 val patternRegistry = registryAccess.getRegistry(RegistryKey.TRIM_PATTERN)
                 val materialRegistry = registryAccess.getRegistry(RegistryKey.TRIM_MATERIAL)
                 val trimPatternKey = armorTrim?.let { patternRegistry.getKey(it.pattern).toString() }
                 val trimMaterialKey = armorTrim?.let { materialRegistry.getKey(it.material).toString() }
 
-                // Get banner pattern and color
+                // Get banner pattern and colour
                 val bannerPatternRegistry = registryAccess.getRegistry(RegistryKey.BANNER_PATTERN)
                 val bannerMeta = newIcon.itemMeta as? BannerMeta
                 val bannerPatterns = bannerMeta?.patterns?.mapNotNull { p ->
@@ -116,7 +116,7 @@ class WarpIconMenu(private val player: Player,
                 val skullTextureValue = textures?.value
                 val skullTextureSignature = textures?.signature
 
-                // Get firework color
+                // Get firework colour
                 val fireworkStarColorRgb = (newIcon.itemMeta as? FireworkEffectMeta)
                     ?.effect
                     ?.colors

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpManagementMenu.kt
@@ -8,14 +8,13 @@ import dev.mizarc.waystonewarps.application.actions.management.ToggleLock
 import dev.mizarc.waystonewarps.domain.warps.Warp
 import dev.mizarc.waystonewarps.interaction.menus.Menu
 import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
+import dev.mizarc.waystonewarps.interaction.utils.customModelData
 import dev.mizarc.waystonewarps.interaction.utils.getWarpMoveTool
 import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
-import net.kyori.adventure.text.format.NamedTextColor
 import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
-import org.checkerframework.checker.units.qual.s
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -65,7 +64,7 @@ class WarpManagementMenu(private val player: Player, private val menuNavigator: 
         pane.addItem(guiRenamingItem, 3, 0)
 
         // Add icon editor button
-        val iconEditorItem = ItemStack(Material.valueOf(warp.icon))
+        val iconEditorItem = ItemStack(Material.valueOf(warp.icon)).customModelData(warp.iconMeta)
             .name("§rEdit Warp Icon")
             .lore("Changes the icon that shows up on the warp list")
         val guiIconEditorItem = GuiItem(iconEditorItem) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpManagementMenu.kt
@@ -8,7 +8,7 @@ import dev.mizarc.waystonewarps.application.actions.management.ToggleLock
 import dev.mizarc.waystonewarps.domain.warps.Warp
 import dev.mizarc.waystonewarps.interaction.menus.Menu
 import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
-import dev.mizarc.waystonewarps.interaction.utils.customModelData
+import dev.mizarc.waystonewarps.interaction.utils.applyIconMeta
 import dev.mizarc.waystonewarps.interaction.utils.getWarpMoveTool
 import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
@@ -64,7 +64,7 @@ class WarpManagementMenu(private val player: Player, private val menuNavigator: 
         pane.addItem(guiRenamingItem, 3, 0)
 
         // Add icon editor button
-        val iconEditorItem = ItemStack(Material.valueOf(warp.icon)).customModelData(warp.iconMeta)
+        val iconEditorItem = ItemStack(Material.valueOf(warp.icon)).applyIconMeta(warp.iconMeta)
             .name("§rEdit Warp Icon")
             .lore("Changes the icon that shows up on the warp list")
         val guiIconEditorItem = GuiItem(iconEditorItem) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -17,6 +17,7 @@ import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
 import dev.mizarc.waystonewarps.interaction.messaging.AccentColourPalette
 import dev.mizarc.waystonewarps.interaction.messaging.PrimaryColourPalette
 import dev.mizarc.waystonewarps.interaction.models.toViewModel
+import dev.mizarc.waystonewarps.interaction.utils.customModelData
 import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
@@ -228,7 +229,7 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             if (warp.isLocked && !getWhitelistedPlayers.execute(warp.id).contains(player.uniqueId)
                     && player.uniqueId != warp.playerId) {
                 customLore.add(2, "§cLOCKED")
-                val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(customLore)
+                val warpItem = ItemStack(warpModel.icon).customModelData(warp.iconMeta).name(warpModel.name).lore(customLore)
                 guiWarpItem = GuiItem(warpItem) { guiEvent ->
                     if (guiEvent.isRightClick) {
                         // Right click to open options
@@ -238,7 +239,7 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             }
             else {
                 customLore.add(2, "Left Click to teleport")
-                val warpItem = ItemStack(warpModel.icon).name(warpModel.name).lore(customLore)
+                val warpItem = ItemStack(warpModel.icon).customModelData(warp.iconMeta).name(warpModel.name).lore(customLore)
                 guiWarpItem = GuiItem(warpItem) {guiEvent ->
 
                     if (guiEvent.isRightClick) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -17,7 +17,7 @@ import dev.mizarc.waystonewarps.interaction.menus.MenuNavigator
 import dev.mizarc.waystonewarps.interaction.messaging.AccentColourPalette
 import dev.mizarc.waystonewarps.interaction.messaging.PrimaryColourPalette
 import dev.mizarc.waystonewarps.interaction.models.toViewModel
-import dev.mizarc.waystonewarps.interaction.utils.customModelData
+import dev.mizarc.waystonewarps.interaction.utils.applyIconMeta
 import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
@@ -229,7 +229,7 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             if (warp.isLocked && !getWhitelistedPlayers.execute(warp.id).contains(player.uniqueId)
                     && player.uniqueId != warp.playerId) {
                 customLore.add(2, "§cLOCKED")
-                val warpItem = ItemStack(warpModel.icon).customModelData(warp.iconMeta).name(warpModel.name).lore(customLore)
+                val warpItem = ItemStack(warpModel.icon).applyIconMeta(warp.iconMeta).name(warpModel.name).lore(customLore)
                 guiWarpItem = GuiItem(warpItem) { guiEvent ->
                     if (guiEvent.isRightClick) {
                         // Right click to open options
@@ -239,7 +239,7 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             }
             else {
                 customLore.add(2, "Left Click to teleport")
-                val warpItem = ItemStack(warpModel.icon).customModelData(warp.iconMeta).name(warpModel.name).lore(customLore)
+                val warpItem = ItemStack(warpModel.icon).applyIconMeta(warp.iconMeta).name(warpModel.name).lore(customLore)
                 guiWarpItem = GuiItem(warpItem) {guiEvent ->
 
                     if (guiEvent.isRightClick) {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
@@ -7,6 +7,8 @@ import io.papermc.paper.datacomponent.item.CustomModelData
 import io.papermc.paper.registry.RegistryAccess
 import io.papermc.paper.registry.RegistryKey
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextColor
 import org.bukkit.*
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.inventory.ItemFlag
@@ -31,34 +33,34 @@ fun ItemStack.amount(amount: Int): ItemStack {
     return this
 }
 
-fun ItemStack.name(name: String): ItemStack {
+fun ItemStack.name(name: String, color: TextColor = NamedTextColor.GOLD): ItemStack {
     val meta = itemMeta
     meta.addItemFlags(*ItemFlag.entries.toTypedArray())
-    meta.displayName(Component.text(name))
+    meta.displayName(Component.text(name).color(color).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false))
     itemMeta = meta
     return this
 }
 
-fun ItemStack.lore(text: String): ItemStack {
-    val meta = itemMeta
-    var lore: MutableList<String>? = meta!!.lore
-    if (lore == null) {
-        lore = ArrayList()
-    }
-    lore.add(text)
-    meta.lore = lore.c()
+fun ItemStack.lore(text: String, color: TextColor = NamedTextColor.GRAY): ItemStack {
+    val meta = itemMeta ?: return this
+    val currentLore = meta.lore() ?: mutableListOf()
+
+    // Add new line with specified color and no italics
+    currentLore.add(Component.text(text).color(color).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false))
+
+    meta.lore(currentLore)
     itemMeta = meta
     return this
 }
 
-fun ItemStack.lore(vararg text: String): ItemStack {
-    Arrays.stream(text).forEach { this.lore(it) }
+fun ItemStack.lore(vararg text: String, color: TextColor = NamedTextColor.GRAY): ItemStack {
+    Arrays.stream(text).forEach { this.lore(it, color) }
     return this
 }
 
-fun ItemStack.lore(text: List<String>): ItemStack {
+fun ItemStack.lore(text: List<String>, color: TextColor = NamedTextColor.GRAY): ItemStack {
     this.clearLore()
-    text.forEach { this.lore(it) }
+    text.forEach { this.lore(it, color) }
     return this
 }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
@@ -1,5 +1,8 @@
 package dev.mizarc.waystonewarps.interaction.utils
 
+import IconMeta
+import io.papermc.paper.datacomponent.DataComponentTypes
+import io.papermc.paper.datacomponent.item.CustomModelData
 import net.kyori.adventure.text.Component
 import org.bukkit.*
 import org.bukkit.enchantments.Enchantment
@@ -10,6 +13,7 @@ import org.bukkit.material.MaterialData
 import org.bukkit.persistence.PersistentDataType
 import java.util.*
 import java.util.function.Consumer
+import org.bukkit.Color
 
 
 fun ItemStack.amount(amount: Int): ItemStack {
@@ -131,6 +135,19 @@ fun ItemStack.setStringMeta(key: String, value: String): ItemStack {
     meta.persistentDataContainer.set(
         NamespacedKey("waystonewarps",key), PersistentDataType.STRING, value)
     itemMeta = meta
+    return this
+}
+
+@Suppress("UnstableApiUsage")
+fun ItemStack.customModelData(meta: IconMeta): ItemStack {
+    val builder = CustomModelData.customModelData()
+
+    meta.strings.forEach(builder::addString)
+    meta.floats.forEach(builder::addFloat)
+    meta.flags.forEach(builder::addFlag)
+    meta.colorsArgb.forEach { argb -> builder.addColor(Color.fromARGB(argb)) }
+
+    this.setData(DataComponentTypes.CUSTOM_MODEL_DATA, builder.build())
     return this
 }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
@@ -14,6 +14,7 @@ import org.bukkit.persistence.PersistentDataType
 import java.util.*
 import java.util.function.Consumer
 import org.bukkit.Color
+import org.bukkit.inventory.meta.PotionMeta
 
 
 fun ItemStack.amount(amount: Int): ItemStack {
@@ -139,13 +140,38 @@ fun ItemStack.setStringMeta(key: String, value: String): ItemStack {
 }
 
 @Suppress("UnstableApiUsage")
-fun ItemStack.customModelData(meta: IconMeta): ItemStack {
-    val builder = CustomModelData.customModelData()
+fun ItemStack.applyIconMeta(meta: IconMeta): ItemStack {
 
+    // Custom model data
+    val builder = CustomModelData.customModelData()
     meta.strings.forEach(builder::addString)
     meta.floats.forEach(builder::addFloat)
     meta.flags.forEach(builder::addFlag)
     meta.colorsArgb.forEach { argb -> builder.addColor(Color.fromARGB(argb)) }
+
+    // Potion base type
+    if (meta.potionTypeKey != null) {
+        val potionKey = NamespacedKey.fromString(meta.potionTypeKey)
+        if (potionKey != null) {
+            val potionType = Registry.POTION.get(potionKey)
+            if (potionType != null) {
+                val im = this.itemMeta
+                if (im is PotionMeta) {
+                    im.basePotionType = potionType
+                    this.itemMeta = im
+                }
+            }
+        }
+    }
+
+    // Leather armor dye color
+    if (meta.leatherColorRgb != null) {
+        val im = this.itemMeta
+        if (im is LeatherArmorMeta) {
+            im.setColor(Color.fromRGB(meta.leatherColorRgb))
+            this.itemMeta = im
+        }
+    }
 
     this.setData(DataComponentTypes.CUSTOM_MODEL_DATA, builder.build())
     return this

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/utils/ItemStackExtensions.kt
@@ -33,7 +33,8 @@ fun ItemStack.amount(amount: Int): ItemStack {
 
 fun ItemStack.name(name: String): ItemStack {
     val meta = itemMeta
-    meta.itemName(Component.text(name))
+    meta.addItemFlags(*ItemFlag.entries.toTypedArray())
+    meta.displayName(Component.text(name))
     itemMeta = meta
     return this
 }


### PR DESCRIPTION
Icons for waystones now support metadata including custom model data, armour dyes, trims, firework colours, potion types. Alongside this is the initial standardisation of menu item elements to have a gold name with grey description by default.