### PR TITLE
Fixed waystones not being covered by protection plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 - Config not being read on the first launch, required restart before the plugin could actually let you do anything.
+- Waystones not being covered by protection plugins even though the block break itself is prevented.
 
 ## [0.3.5]
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneDestructionListener.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/listeners/WaystoneDestructionListener.kt
@@ -13,6 +13,7 @@ import org.bukkit.NamespacedKey
 import org.bukkit.block.Block
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockExplodeEvent
@@ -30,7 +31,7 @@ class WaystoneDestructionListener: Listener, KoinComponent {
     private val getWarpAtPosition: GetWarpAtPosition by inject()
     private val breakWarpBlock: BreakWarpBlock by inject()
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onClaimHubDestroy(event: BlockBreakEvent) {
         val bottomBlockPosition = event.block.location.toPosition3D()
         val topBlockPosition = event.block.location.clone().apply { y += 1 }.toPosition3D()


### PR DESCRIPTION
Even though the blocks themselves are protected by protection plugins, the waystone still gets destroyed and reverts back to their default blocks. This easy fix cancels the listener action when the event is cancelled.