### PR TITLE
Implement removal of old warps in missing worlds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - `/waystonewarps invalids remove <id>` Removes warps for a given world.
   - `/waystonewarps invalids removeall`: Removes all warps for missing worlds.
 - New permissions to use the invalids command system:
+  - `waystonewarps.admin.invalids.list`: Allows usage of the list command
+  - `waystonewarps.admin.invalids.remove`: Allows usage of remove command
   - `waystonewarps.admin.invalids.removeall`: Allows usage of removeall command
 
 ### Changed
@@ -31,6 +33,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Fixed
 - Config not being read on the first launch, required restart before the plugin could actually let you do anything.
 - Waystones not being covered by protection plugins even though the block break itself is prevented.
+- Whitelists not being removed from the database when the waystone is removed.
 
 ## [0.3.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - `waystonewarps.bypass.rename`: Allows access to rename the waystone.
   - `waystonewarps.bypass.icon`: Allows access to change the waystone icon.
   - `waystonewarps.bypass.relocate`: Allows access to relocate the waystone.
+- Add new command system to remove invalid warp world data:
+  - `/waystonewarps invalids list`: Lists missing worlds containing warps
+  - `/waystonewarps invalids remove <id>` Removes warps for a given world.
+  - `/waystonewarps invalids removeall`: Removes all warps for missing worlds.
+- New permissions to use the invalids command system:
+  - `waystonewarps.admin.invalids.removeall`: Allows usage of removeall command
 
 ### Changed
 - Menu buttons are now gold with a grey description for standardisation.

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -199,7 +199,7 @@ class WaystoneWarps: JavaPlugin() {
             single { UpdateWarpName(warpRepository, hologramService) }
             single { GetWarpAtPosition(warpRepository) }
             single { BreakWarpBlock(warpRepository, structureBuilderService,
-                discoveryRepository, structureParticleService, hologramService) }
+                discoveryRepository, whitelistRepository, structureParticleService, hologramService) }
             single { TeleportPlayer(teleportationService, playerAttributeService, playerParticleService,
                 discoveryRepository)}
             single { LogPlayerMovement(movementMonitorService) }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -218,8 +218,8 @@ class WaystoneWarps: JavaPlugin() {
             single { GetFavouritedWarpAccess(discoveryRepository, warpRepository) }
             single { GetOwnedWarps(warpRepository) }
             single { ListInvalidWarps(warpRepository, worldService) }
-            single { RemoveAllInvalidWarps(warpRepository, worldService) }
-            single { RemoveInvalidWarpsForWorld(warpRepository, worldService) }
+            single { RemoveAllInvalidWarps(warpRepository, worldService, discoveryRepository, whitelistRepository) }
+            single { RemoveInvalidWarpsForWorld(warpRepository, worldService, discoveryRepository, whitelistRepository) }
         }
 
         startKoin { modules(repositories, actions) }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/ListInvalidWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/ListInvalidWarps.kt
@@ -1,0 +1,17 @@
+package dev.mizarc.waystonewarps.application.actions.administration
+
+import dev.mizarc.waystonewarps.domain.warps.Warp
+import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+import dev.mizarc.waystonewarps.domain.world.WorldService
+
+class ListInvalidWarps(private val warpRepository: WarpRepository, private val worldService: WorldService) {
+    /**
+     * Lists all warps that are in invalid worlds.
+     *
+     * @return A list of warps that are in invalid worlds.
+     */
+    fun listAllInvalidWarps(): List<Warp> {
+        return warpRepository.getAll()
+            .filter { worldService.isWorldInvalid(it.worldId) }
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveAllInvalidWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveAllInvalidWarps.kt
@@ -1,0 +1,32 @@
+package dev.mizarc.waystonewarps.application.actions.administration
+
+import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+import dev.mizarc.waystonewarps.domain.world.WorldService
+
+/**
+ * Handles the removal of warps that are in invalid worlds.
+ *
+ * @property warpRepository The repository for accessing warp data.
+ * @property worldService The service for world-related operations.
+ */
+class RemoveAllInvalidWarps(
+    private val warpRepository: WarpRepository,
+    private val worldService: WorldService
+) {
+
+    /**
+     * Removes all warps in invalid worlds.
+     *
+     * @return A Pair where the first value is the number of warps removed and the second is the total number of warps checked.
+     */
+    fun execute(): Pair<Int, Int> {
+        val allWarps = warpRepository.getAll()
+        val invalidWarps = allWarps.filter { worldService.isWorldInvalid(it.worldId) }
+
+        invalidWarps.forEach { warp ->
+            warpRepository.remove(warp.id)
+        }
+
+        return Pair(invalidWarps.size, allWarps.size)
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveAllInvalidWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveAllInvalidWarps.kt
@@ -1,6 +1,8 @@
 package dev.mizarc.waystonewarps.application.actions.administration
 
+import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+import dev.mizarc.waystonewarps.domain.whitelist.WhitelistRepository
 import dev.mizarc.waystonewarps.domain.world.WorldService
 
 /**
@@ -8,12 +10,15 @@ import dev.mizarc.waystonewarps.domain.world.WorldService
  *
  * @property warpRepository The repository for accessing warp data.
  * @property worldService The service for world-related operations.
+ * @property discoveryRepository The repository for managing warp discoveries.
+ * @property whitelistRepository The repository for managing warp whitelists.
  */
 class RemoveAllInvalidWarps(
     private val warpRepository: WarpRepository,
-    private val worldService: WorldService
+    private val worldService: WorldService,
+    private val discoveryRepository: DiscoveryRepository,
+    private val whitelistRepository: WhitelistRepository
 ) {
-
     /**
      * Removes all warps in invalid worlds.
      *
@@ -24,6 +29,15 @@ class RemoveAllInvalidWarps(
         val invalidWarps = allWarps.filter { worldService.isWorldInvalid(it.worldId) }
 
         invalidWarps.forEach { warp ->
+            // Remove all discoveries for this warp
+            discoveryRepository.getByWarp(warp.id).forEach { discovery ->
+                discoveryRepository.remove(discovery.warpId, discovery.playerId)
+            }
+            
+            // Remove all whitelist entries for this warp
+            whitelistRepository.removeByWarp(warp.id)
+            
+            // Remove the warp itself
             warpRepository.remove(warp.id)
         }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveInvalidWarpsForWorld.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveInvalidWarpsForWorld.kt
@@ -1,21 +1,27 @@
 package dev.mizarc.waystonewarps.application.actions.administration
 
+import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+import dev.mizarc.waystonewarps.domain.whitelist.WhitelistRepository
 import dev.mizarc.waystonewarps.domain.world.WorldService
 import java.util.UUID
 
 /**
- * Handles the removal of warps in invalid worlds for a specific player.
+ * Handles the removal of warps in invalid worlds for a specific world.
  *
  * @property warpRepository The repository for accessing warp data.
  * @property worldService The service for world-related operations.
+ * @property discoveryRepository The repository for managing warp discoveries.
+ * @property whitelistRepository The repository for managing warp whitelists.
  */
 class RemoveInvalidWarpsForWorld(
     private val warpRepository: WarpRepository,
-    private val worldService: WorldService
+    private val worldService: WorldService,
+    private val discoveryRepository: DiscoveryRepository,
+    private val whitelistRepository: WhitelistRepository
 ) {
     /**
-     * Removes warps in invalid worlds for a specific player.
+     * Removes warps in invalid worlds for a specific world.
      *
      * @param worldId The world to remove invalid warps from.
      * @return A Pair where the first value is the number of warps removed.
@@ -25,6 +31,15 @@ class RemoveInvalidWarpsForWorld(
         val invalidWarps = allWarps.filter { worldService.isWorldInvalid(it.worldId) }
 
         invalidWarps.forEach { warp ->
+            // Remove all discoveries for this warp
+            discoveryRepository.getByWarp(warp.id).forEach { discovery ->
+                discoveryRepository.remove(discovery.warpId, discovery.playerId)
+            }
+            
+            // Remove all whitelist entries for this warp
+            whitelistRepository.removeByWarp(warp.id)
+            
+            // Remove the warp itself
             warpRepository.remove(warp.id)
         }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveInvalidWarpsForWorld.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveInvalidWarpsForWorld.kt
@@ -1,0 +1,33 @@
+package dev.mizarc.waystonewarps.application.actions.administration
+
+import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+import dev.mizarc.waystonewarps.domain.world.WorldService
+import java.util.UUID
+
+/**
+ * Handles the removal of warps in invalid worlds for a specific player.
+ *
+ * @property warpRepository The repository for accessing warp data.
+ * @property worldService The service for world-related operations.
+ */
+class RemoveInvalidWarpsForWorld(
+    private val warpRepository: WarpRepository,
+    private val worldService: WorldService
+) {
+    /**
+     * Removes warps in invalid worlds for a specific player.
+     *
+     * @param worldId The world to remove invalid warps from.
+     * @return A Pair where the first value is the number of warps removed.
+     */
+    fun execute(worldId: UUID): Pair<Int, Int> {
+        val allWarps = warpRepository.getByWorld(worldId)
+        val invalidWarps = allWarps.filter { worldService.isWorldInvalid(it.worldId) }
+
+        invalidWarps.forEach { warp ->
+            warpRepository.remove(warp.id)
+        }
+
+        return Pair(invalidWarps.size, allWarps.size)
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/WarpRepository.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/WarpRepository.kt
@@ -30,6 +30,15 @@ interface WarpRepository {
      */
     fun getByPlayer(playerId: UUID): List<Warp>
 
+
+    /**
+     * Gets all warps for a particular world.
+     *
+     * @param worldId The world to retrieve the warps for.
+     * @return A set of warps in the world.
+     */
+    fun getByWorld(worldId: UUID): List<Warp>
+
     /**
      * Gets a warp owned by a player by name.
      *

--- a/src/main/kotlin/dev/mizarc/waystonewarps/domain/world/WorldService.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/domain/world/WorldService.kt
@@ -1,0 +1,24 @@
+package dev.mizarc.waystonewarps.domain.world
+
+import java.util.UUID
+
+/**
+ * Service for world-related operations.
+ */
+interface WorldService {
+    /**
+     * Checks if a world is invalid (doesn't exist or isn't loaded).
+     *
+     * @param worldId The UUID of the world to check
+     * @return true if the world is invalid, false otherwise
+     */
+    fun isWorldInvalid(worldId: UUID): Boolean
+
+    /**
+     * Checks if a world name is invalid (doesn't exist or isn't loaded).
+     *
+     * @param worldName The name of the world to check
+     * @return true if the world is invalid, false otherwise
+     */
+    fun isWorldInvalid(worldName: String): Boolean
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/persistence/warps/WarpRepositorySQLite.kt
@@ -35,6 +35,10 @@ class WarpRepositorySQLite(private val storage: Storage<Database>): WarpReposito
         return warps.values.filter { it.playerId == playerId }
     }
 
+    override fun getByWorld(worldId: UUID): List<Warp> {
+        return warps.values.filter { it.worldId == worldId }
+    }
+
     override fun getByName(playerId: UUID, name: String): Warp? {
         return warps.values.find { it.playerId == playerId && it.name.equals(name, ignoreCase = true) }
     }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/WorldServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/WorldServiceBukkit.kt
@@ -1,0 +1,18 @@
+package dev.mizarc.waystonewarps.infrastructure.services
+
+import dev.mizarc.waystonewarps.domain.world.WorldService
+import org.bukkit.Bukkit
+import java.util.UUID
+
+/**
+ * Bukkit implementation of WorldService.
+ */
+class WorldServiceBukkit : WorldService {
+    override fun isWorldInvalid(worldId: UUID): Boolean {
+        return Bukkit.getWorld(worldId) == null
+    }
+
+    override fun isWorldInvalid(worldName: String): Boolean {
+        return Bukkit.getWorld(worldName) == null
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/InvalidsCommand.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/InvalidsCommand.kt
@@ -1,0 +1,52 @@
+package dev.mizarc.waystonewarps.interaction.commands
+
+import co.aikar.commands.BaseCommand
+import co.aikar.commands.annotation.*
+import dev.mizarc.waystonewarps.application.actions.management.RemoveInvalidWarps
+import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
+import org.bukkit.command.CommandSender
+
+@CommandAlias("waystonewarps|ww")
+@CommandPermission("waystonewarps.admin.invalids")
+class InvalidsCommand(private val removeInvalidWarps: RemoveInvalidWarps) : BaseCommand() {
+
+    @Subcommand("invalids list")
+    @CommandPermission("waystonewarps.admin.invalids.list")
+    @Description("List all warps in invalid worlds")
+    fun onListInvalids(sender: CommandSender, @Optional @Name("player") targetPlayer: OfflinePlayer?) {
+        val warps = if (targetPlayer != null) {
+            removeInvalidWarps.listInvalidWarps(targetPlayer.uniqueId)
+        } else {
+            removeInvalidWarps.listAllInvalidWarps()
+        }
+
+        if (warps.isEmpty()) {
+            sender.sendMessage("§aNo invalid warps found.")
+            return
+        }
+
+        sender.sendMessage("§6=== Invalid Warps (${warps.size}) ===")
+        warps.forEach { warp ->
+            val playerName = Bukkit.getOfflinePlayer(warp.playerId).name ?: "Unknown"
+            sender.sendMessage("§7- §f${warp.name} §7(Owner: $playerName, World: ${warp.worldId})")
+        }
+    }
+
+    @Subcommand("invalids remove")
+    @CommandPermission("waystonewarps.admin.invalids.remove")
+    @Description("Remove warps in invalid worlds")
+    fun onRemoveInvalids(sender: CommandSender, @Optional @Name("player") targetPlayer: OfflinePlayer?) {
+        val (removed, total) = if (targetPlayer != null) {
+            removeInvalidWarps.execute(targetPlayer.uniqueId)
+        } else {
+            removeInvalidWarps.execute()
+        }
+
+        if (targetPlayer != null) {
+            sender.sendMessage("§aRemoved $removed invalid warps for ${targetPlayer.name} (out of $total checked).")
+        } else {
+            sender.sendMessage("§aRemoved $removed invalid warps (out of $total checked).")
+        }
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/InvalidsCommand.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/InvalidsCommand.kt
@@ -17,7 +17,6 @@ import org.koin.core.component.inject
 import java.util.*
 
 @CommandAlias("waystonewarps|ww")
-@CommandPermission("waystonewarps.admin.invalids")
 class InvalidsCommand : BaseCommand(), KoinComponent {
     private val listInvalidWarps: ListInvalidWarps by inject()
     private val removeAllInvalidWarps: RemoveAllInvalidWarps by inject()

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/InvalidsCommand.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/InvalidsCommand.kt
@@ -2,51 +2,85 @@ package dev.mizarc.waystonewarps.interaction.commands
 
 import co.aikar.commands.BaseCommand
 import co.aikar.commands.annotation.*
-import dev.mizarc.waystonewarps.application.actions.management.RemoveInvalidWarps
+import dev.mizarc.waystonewarps.application.actions.administration.ListInvalidWarps
+import dev.mizarc.waystonewarps.application.actions.administration.RemoveAllInvalidWarps
+import dev.mizarc.waystonewarps.application.actions.administration.RemoveInvalidWarpsForWorld
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.HoverEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Bukkit
-import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+import java.util.*
 
 @CommandAlias("waystonewarps|ww")
 @CommandPermission("waystonewarps.admin.invalids")
-class InvalidsCommand(private val removeInvalidWarps: RemoveInvalidWarps) : BaseCommand() {
+class InvalidsCommand(
+    private val listInvalidWarps: ListInvalidWarps,
+    private val removeAllInvalidWarps: RemoveAllInvalidWarps,
+    private val removeInvalidWarpsForWorld: RemoveInvalidWarpsForWorld
+) : BaseCommand() {
 
     @Subcommand("invalids list")
     @CommandPermission("waystonewarps.admin.invalids.list")
     @Description("List all warps in invalid worlds")
-    fun onListInvalids(sender: CommandSender, @Optional @Name("player") targetPlayer: OfflinePlayer?) {
-        val warps = if (targetPlayer != null) {
-            removeInvalidWarps.listInvalidWarps(targetPlayer.uniqueId)
-        } else {
-            removeInvalidWarps.listAllInvalidWarps()
-        }
+    fun onListInvalids(sender: CommandSender) {
+        val warps = listInvalidWarps.listAllInvalidWarps()
 
         if (warps.isEmpty()) {
-            sender.sendMessage("§aNo invalid warps found.")
+            sender.sendMessage(Component.text("No invalid warps found.", NamedTextColor.GREEN))
             return
         }
 
-        sender.sendMessage("§6=== Invalid Warps (${warps.size}) ===")
-        warps.forEach { warp ->
-            val playerName = Bukkit.getOfflinePlayer(warp.playerId).name ?: "Unknown"
-            sender.sendMessage("§7- §f${warp.name} §7(Owner: $playerName, World: ${warp.worldId})")
+        // Group warps by world ID and count them
+        val warpsByWorld = warps.groupBy { it.worldId }
+            .mapValues { (_, warpsInWorld) -> warpsInWorld.size }
+            .toList()
+            .sortedByDescending { (_, count) -> count }
+
+        val header = Component.text()
+            .content("--- Invalid Warps (${warps.size} total) ---")
+            .color(NamedTextColor.GOLD)
+            .build()
+        sender.sendMessage(header)
+        warpsByWorld.forEach { (worldId, count) ->
+            val worldIdStr = worldId.toString()
+            val message = Component.text("-", NamedTextColor.GRAY)
+                .append(Component.space())
+                .append(Component.text(worldIdStr, NamedTextColor.RED))
+                .append(Component.text(": ", NamedTextColor.GRAY))
+                .append(Component.text("$count warps", NamedTextColor.WHITE))
+            
+            if (sender is Player) {
+                // For players, add click and hover events
+                val clickableMessage = message
+                    .clickEvent(ClickEvent.copyToClipboard(worldIdStr))
+                    .hoverEvent(HoverEvent.showText(Component.text("Click to copy world ID to clipboard", NamedTextColor.GREEN)))
+                
+                sender.sendMessage(clickableMessage)
+            } else {
+                // Fallback for console/non-player senders
+                sender.sendMessage(message)
+            }
         }
     }
 
     @Subcommand("invalids remove")
     @CommandPermission("waystonewarps.admin.invalids.remove")
-    @Description("Remove warps in invalid worlds")
-    fun onRemoveInvalids(sender: CommandSender, @Optional @Name("player") targetPlayer: OfflinePlayer?) {
-        val (removed, total) = if (targetPlayer != null) {
-            removeInvalidWarps.execute(targetPlayer.uniqueId)
-        } else {
-            removeInvalidWarps.execute()
-        }
+    @Description("Remove warps in a specific world")
+    fun onRemoveInvalids(sender: CommandSender, @Name("world") worldId: UUID) {
+        val (removed, total) = removeInvalidWarpsForWorld.execute(worldId)
+        val worldName = Bukkit.getWorld(worldId)?.name ?: worldId.toString()
+        sender.sendMessage("§aRemoved $removed warps from world '$worldName' (out of $total checked).")
+    }
 
-        if (targetPlayer != null) {
-            sender.sendMessage("§aRemoved $removed invalid warps for ${targetPlayer.name} (out of $total checked).")
-        } else {
-            sender.sendMessage("§aRemoved $removed invalid warps (out of $total checked).")
-        }
+    @Subcommand("invalids removeall")
+    @CommandPermission("waystonewarps.admin.invalids.removeall")
+    @Description("Remove all warps in invalid worlds")
+    fun onRemoveAllInvalids(sender: CommandSender) {
+        val (removed, total) = removeAllInvalidWarps.execute()
+        sender.sendMessage("§aRemoved $removed invalid warps (out of $total checked).")
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -42,3 +42,23 @@ permissions:
   waystonewarps.bypass.openmenu:
     description: Can open other players' waystone menus
     default: op
+
+  waystonewarps.admin.invalids.*:
+    description: Access to all invalid warp management commands
+    default: op
+    children:
+      waystonewarps.admin.invalids.list: true
+      waystonewarps.admin.invalids.remove: true
+      waystonewarps.admin.invalids.removeall: true
+
+  waystonewarps.admin.invalids.list:
+    description: Allows listing warps in invalid worlds
+    default: op
+
+  waystonewarps.admin.invalids.remove:
+    description: Allows removing warps from specific invalid worlds
+    default: op
+
+  waystonewarps.admin.invalids.removeall:
+    description: Allows removing all warps from all invalid worlds
+    default: op


### PR DESCRIPTION
When the worlds that previously contained warps no longer exist, administrators need a way to remove the old warps otherwise they will occupy player's warp limits permanently.

### Add new command system to remove invalid warp world data:
  - `/waystonewarps invalids list`: Lists missing worlds containing warps
  - `/waystonewarps invalids remove <id>` Removes warps for a given world.
  - `/waystonewarps invalids removeall`: Removes all warps for missing worlds.

### New permissions to use the invalids command system:
  - `waystonewarps.admin.invalids.list`: Allows usage of the list command
  - `waystonewarps.admin.invalids.remove`: Allows usage of remove command
  - `waystonewarps.admin.invalids.removeall`: Allows usage of removeall command

Alongside this is an additional fix to remove the whitelist from the database when waystones are destroyed.
