### PR TITLE
Fix pagination not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Config not being read on the first launch, required restart before the plugin could actually let you do anything.
 - Waystones not being covered by protection plugins even though the block break itself is prevented.
 - Whitelists not being removed from the database when the waystone is removed.
+- Pagination for warps and player access were not showing correctly.
 
 ## [0.3.5]
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpPlayerMenu.kt
@@ -213,8 +213,6 @@ class WarpPlayerMenu(private val player: Player, private val menuNavigator: Menu
                 }
             }
             paginatorPane.addItem(guiNextItem, 2, 0)
-
-            gui.update()
         }
 
         updatePaginator()

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -164,7 +164,6 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             // Update page number item
             val pageNumberItem = ItemStack(Material.PAPER).name("Page $currentPage of $totalPages")
             val guiPageNumberItem = GuiItem(pageNumberItem)
-            // Clear previous page number
             paginatorPane.addItem(guiPageNumberItem, 1, 0)
 
             // Update left arrow
@@ -201,7 +200,6 @@ class WarpMenu(private val player: Player, private val menuNavigator: MenuNaviga
             }
             paginatorPane.addItem(guiNextItem, 2, 0)
 
-            gui.update()
         }
 
         updatePaginator()


### PR DESCRIPTION
Pagination for warps and player access were not showing correctly. Just had to remove a gui update line that was being run prematurely. Thought this was a feature that wasn't implemented at first, but it turns out the code was all there and it was just a bug.