### PR TITLE
Expose a basic API that can be leveraged by third party plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - `waystonewarps.bypass.icon`: Allows access to change the waystone icon.
   - `waystonewarps.bypass.relocate`: Allows access to relocate the waystone.
 - Add new command system to remove invalid warp world data:
-  - `/waystonewarps invalids list`: Lists missing worlds containing warps
+  - `/waystonewarps invalids list`: Lists missing worlds containing warps.
   - `/waystonewarps invalids remove <id>` Removes warps for a given world.
   - `/waystonewarps invalids removeall`: Removes all warps for missing worlds.
 - New permissions to use the invalids command system:
-  - `waystonewarps.admin.invalids.list`: Allows usage of the list command
-  - `waystonewarps.admin.invalids.remove`: Allows usage of remove command
-  - `waystonewarps.admin.invalids.removeall`: Allows usage of removeall command
+  - `waystonewarps.admin.invalids.list`: Allows usage of the list command.
+  - `waystonewarps.admin.invalids.remove`: Allows usage of remove command.
+  - `waystonewarps.admin.invalids.removeall`: Allows usage of removeall command.
+- New API to get warps and listen to events:
+  - `WaystoneWarpsAPI`: Provides getters to get warp data.
+  - `WarpCreateEvent`: Called when a warp is created.
+  - `WarpDeleteEvent`: Called when a warp is deleted.
+  - `WarpUpdateEvent`: Called when a warp is updated.
 
 ### Changed
 - Menu buttons are now gold with a grey description for standardisation.

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -57,6 +57,7 @@ import dev.mizarc.waystonewarps.interaction.commands.InvalidsCommand
 import dev.mizarc.waystonewarps.interaction.listeners.*
 import net.milkbowl.vault.economy.Economy
 import org.bukkit.Bukkit
+import org.bukkit.plugin.ServicePriority
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
 import java.io.File
@@ -133,6 +134,7 @@ class WaystoneWarps: JavaPlugin() {
 
         // Initialise API
         api = WaystoneWarpsAPI(warpRepository)
+        server.servicesManager.register( WaystoneWarpsAPI::class.java, api, this, ServicePriority.Normal )
 
         for (warp in warpRepository.getAll()) {
             structureParticleService.spawnParticles(warp)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -94,6 +94,7 @@ class WaystoneWarps: JavaPlugin() {
     private lateinit var hologramService: HologramService
     private lateinit var configService: ConfigService
     private lateinit var scheduler: SchedulerService
+    private lateinit var warpEventPublisher: WarpEventPublisher
 
     override fun onEnable() {
         // Create plugin folder
@@ -189,6 +190,7 @@ class WaystoneWarps: JavaPlugin() {
         playerParticleService = PlayerParticleServiceBukkit(this, playerAttributeService)
         hologramService = HologramServiceBukkit(configService)
         worldService = WorldServiceBukkit()
+        warpEventPublisher = WarpEventPublisherBukkit()
     }
 
     private fun registerDependencies() {
@@ -201,25 +203,25 @@ class WaystoneWarps: JavaPlugin() {
 
         val actions = module {
             single { CreateWarp(warpRepository, playerAttributeService, structureBuilderService,
-                discoveryRepository, structureParticleService, hologramService) }
+                discoveryRepository, structureParticleService, hologramService, warpEventPublisher) }
             single { GetWarpPlayerAccess(discoveryRepository) }
             single { GetPlayerWarpAccess(discoveryRepository, warpRepository) }
-            single { UpdateWarpIcon(warpRepository) }
-            single { UpdateWarpName(warpRepository, hologramService) }
+            single { UpdateWarpIcon(warpRepository, warpEventPublisher) }
+            single { UpdateWarpName(warpRepository, hologramService, warpEventPublisher) }
             single { GetWarpAtPosition(warpRepository) }
             single { BreakWarpBlock(warpRepository, structureBuilderService,
-                discoveryRepository, whitelistRepository, structureParticleService, hologramService) }
+                discoveryRepository, whitelistRepository, structureParticleService, hologramService, warpEventPublisher) }
             single { TeleportPlayer(teleportationService, playerAttributeService, playerParticleService,
                 discoveryRepository)}
             single { LogPlayerMovement(movementMonitorService) }
             single { DiscoverWarp(discoveryRepository) }
-            single { MoveWarp(warpRepository, structureBuilderService, structureParticleService, hologramService) }
-            single { ToggleLock(warpRepository) }
+            single { MoveWarp(warpRepository, structureBuilderService, structureParticleService, hologramService, warpEventPublisher) }
+            single { ToggleLock(warpRepository, warpEventPublisher) }
             single { GetWhitelistedPlayers(whitelistRepository) }
             single { ToggleWhitelist(whitelistRepository, warpRepository) }
             single { RevokeDiscovery(discoveryRepository) }
             single { IsPositionInTeleportZone(warpRepository) }
-            single { UpdateWarpSkin(warpRepository, structureBuilderService, configService) }
+            single { UpdateWarpSkin(warpRepository, structureBuilderService, configService, warpEventPublisher) }
             single { IsValidWarpBase(configService) }
             single { GetAllWarpSkins(configService) }
             single { IsPlayerFavouriteWarp(discoveryRepository) }
@@ -227,8 +229,8 @@ class WaystoneWarps: JavaPlugin() {
             single { GetFavouritedWarpAccess(discoveryRepository, warpRepository) }
             single { GetOwnedWarps(warpRepository) }
             single { ListInvalidWarps(warpRepository, worldService) }
-            single { RemoveAllInvalidWarps(warpRepository, worldService, discoveryRepository, whitelistRepository) }
-            single { RemoveInvalidWarpsForWorld(warpRepository, worldService, discoveryRepository, whitelistRepository) }
+            single { RemoveAllInvalidWarps(warpRepository, worldService, discoveryRepository, whitelistRepository, warpEventPublisher) }
+            single { RemoveInvalidWarpsForWorld(warpRepository, worldService, discoveryRepository, whitelistRepository, warpEventPublisher) }
         }
 
         startKoin { modules(repositories, actions) }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -2,6 +2,7 @@ package dev.mizarc.waystonewarps
 
 import co.aikar.commands.PaperCommandManager
 import co.aikar.idb.Database
+import dev.mizarc.waystonewarps.api.WaystoneWarpsAPI
 import dev.mizarc.waystonewarps.application.actions.administration.ListInvalidWarps
 import dev.mizarc.waystonewarps.application.actions.administration.RemoveAllInvalidWarps
 import dev.mizarc.waystonewarps.application.actions.administration.RemoveInvalidWarpsForWorld
@@ -64,6 +65,11 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 class WaystoneWarps: JavaPlugin() {
+    companion object {
+        lateinit var api: WaystoneWarpsAPI
+            private set
+    }
+
     private lateinit var commandManager: PaperCommandManager
     private lateinit var metadata: Chat
     private var economy: Economy? = null
@@ -72,7 +78,7 @@ class WaystoneWarps: JavaPlugin() {
     private lateinit var storage: Storage<Database>
 
     // Repositories
-    private lateinit var warpRepository: WarpRepository
+    internal lateinit var warpRepository: WarpRepository
     private lateinit var discoveryRepository: DiscoveryRepository
     private lateinit var playerStateRepository: PlayerStateRepository
     private lateinit var whitelistRepository: WhitelistRepository
@@ -123,6 +129,9 @@ class WaystoneWarps: JavaPlugin() {
         registerCommands()
         registerEvents()
         AddAllDisplays(warpRepository, structureBuilderService, hologramService).execute()
+
+        // Initialise API
+        api = WaystoneWarpsAPI(warpRepository)
 
         for (warp in warpRepository.getAll()) {
             structureParticleService.spawnParticles(warp)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/api/WaystoneWarpsAPI.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/api/WaystoneWarpsAPI.kt
@@ -1,0 +1,55 @@
+package dev.mizarc.waystonewarps.api
+
+import dev.mizarc.waystonewarps.WaystoneWarps
+import dev.mizarc.waystonewarps.domain.warps.Warp
+import dev.mizarc.waystonewarps.domain.warps.WarpRepository
+import dev.mizarc.waystonewarps.infrastructure.mappers.toPosition3D
+import org.bukkit.Location
+import org.bukkit.World
+import java.util.*
+
+/**
+ * The main API class for WaystoneWarps. Provides access to waystone data and events.
+ * 
+ * To use the API, get an instance via [WaystoneWarps.getAPI()].
+ */
+class WaystoneWarpsAPI(private val warpRepository: WarpRepository) {
+    /**
+     * Gets all waystones in the server.
+     * @return A set of all waystones
+     */
+    fun getAllWarps(): Set<Warp> = warpRepository.getAll()
+
+    /**
+     * Gets a waystone by its unique ID.
+     * @param id The UUID of the waystone
+     * @return The waystone, or null if not found
+     */
+    fun getWarpById(id: UUID): Warp? = warpRepository.getById(id)
+
+    /**
+     * Gets all waystones owned by a player.
+     * @param playerId The UUID of the player
+     * @return A list of waystones owned by the player
+     */
+    fun getWarpsByPlayer(playerId: UUID): List<Warp> = warpRepository.getByPlayer(playerId)
+
+    /**
+     * Gets all waystones in a specific world.
+     * @param world The world
+     * @return A list of waystones in the world
+     */
+    fun getWarpsInWorld(world: World): List<Warp> = warpRepository.getByWorld(world.uid)
+
+    /**
+     * Gets a waystone at a specific location.
+     * @param location The location to check
+     * @return The waystone at the location, or null if none exists
+     */
+    fun getWarpAtLocation(location: Location): Warp? {
+        return warpRepository.getByPosition(
+            location.toPosition3D(),
+            location.world?.uid ?: return null
+        )
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/api/events/WarpCreateEvent.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/api/events/WarpCreateEvent.kt
@@ -1,0 +1,20 @@
+package dev.mizarc.waystonewarps.api.events
+
+import dev.mizarc.waystonewarps.domain.warps.Warp
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+
+/**
+ * Called when a new waystone is created.
+ * @property warp The warp that was created
+ */
+class WarpCreateEvent(
+    val warp: Warp
+) : Event() {
+    override fun getHandlers(): HandlerList = handlerList
+
+    companion object {
+        @JvmStatic
+        val handlerList = HandlerList()
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/api/events/WarpDeleteEvent.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/api/events/WarpDeleteEvent.kt
@@ -1,0 +1,20 @@
+package dev.mizarc.waystonewarps.api.events
+
+import dev.mizarc.waystonewarps.domain.warps.Warp
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+
+/**
+ * Called when a waystone is deleted.
+ * @property warp The warp that was deleted
+ */
+class WarpDeleteEvent(
+    val warp: Warp
+) : Event() {
+    override fun getHandlers(): HandlerList = handlerList
+
+    companion object {
+        @JvmStatic
+        val handlerList = HandlerList()
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/api/events/WarpUpdateEvent.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/api/events/WarpUpdateEvent.kt
@@ -1,0 +1,22 @@
+package dev.mizarc.waystonewarps.api.events
+
+import dev.mizarc.waystonewarps.domain.warps.Warp
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+
+/**
+ * Called when a waystone's properties are updated.
+ * @property oldWarp The warp data before the update
+ * @property newWarp The warp data after the update
+ */
+class WarpUpdateEvent(
+    val oldWarp: Warp,
+    val newWarp: Warp
+) : Event() {
+    override fun getHandlers(): HandlerList = handlerList
+
+    companion object {
+        @JvmStatic
+        val handlerList = HandlerList()
+    }
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveAllInvalidWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveAllInvalidWarps.kt
@@ -1,5 +1,6 @@
 package dev.mizarc.waystonewarps.application.actions.administration
 
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import dev.mizarc.waystonewarps.domain.whitelist.WhitelistRepository
@@ -17,7 +18,8 @@ class RemoveAllInvalidWarps(
     private val warpRepository: WarpRepository,
     private val worldService: WorldService,
     private val discoveryRepository: DiscoveryRepository,
-    private val whitelistRepository: WhitelistRepository
+    private val whitelistRepository: WhitelistRepository,
+    private val warpEventPublisher: WarpEventPublisher
 ) {
     /**
      * Removes all warps in invalid worlds.
@@ -39,6 +41,7 @@ class RemoveAllInvalidWarps(
             
             // Remove the warp itself
             warpRepository.remove(warp.id)
+            warpEventPublisher.warpDeleted(warp)
         }
 
         return Pair(invalidWarps.size, allWarps.size)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveInvalidWarpsForWorld.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/administration/RemoveInvalidWarpsForWorld.kt
@@ -1,5 +1,6 @@
 package dev.mizarc.waystonewarps.application.actions.administration
 
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import dev.mizarc.waystonewarps.domain.whitelist.WhitelistRepository
@@ -18,7 +19,8 @@ class RemoveInvalidWarpsForWorld(
     private val warpRepository: WarpRepository,
     private val worldService: WorldService,
     private val discoveryRepository: DiscoveryRepository,
-    private val whitelistRepository: WhitelistRepository
+    private val whitelistRepository: WhitelistRepository,
+    private val warpEventPublisher: WarpEventPublisher
 ) {
     /**
      * Removes warps in invalid worlds for a specific world.
@@ -41,6 +43,7 @@ class RemoveInvalidWarpsForWorld(
             
             // Remove the warp itself
             warpRepository.remove(warp.id)
+            warpEventPublisher.warpDeleted(warp)
         }
 
         return Pair(invalidWarps.size, allWarps.size)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/ToggleLock.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/ToggleLock.kt
@@ -1,9 +1,11 @@
 package dev.mizarc.waystonewarps.application.actions.management
 
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import java.util.UUID
 
-class ToggleLock(private val warpRepository: WarpRepository) {
+class ToggleLock(private val warpRepository: WarpRepository,
+                 private val warpEventPublisher: WarpEventPublisher) {
     fun execute(playerId: UUID, warpId: UUID, bypassOwnership: Boolean = false): Result<Unit> {
         val warp = warpRepository.getById(warpId) ?: return Result.failure(Exception("Warp not found"))
 
@@ -12,8 +14,10 @@ class ToggleLock(private val warpRepository: WarpRepository) {
             return Result.failure(Exception("Not authorized"))
         }
 
+        val oldWarp = warp.copy()
         warp.isLocked = !warp.isLocked
         warpRepository.update(warp)
+        warpEventPublisher.warpModified(oldWarp, warp)
         return Result.success(Unit)
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpIcon.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpIcon.kt
@@ -1,10 +1,12 @@
 package dev.mizarc.waystonewarps.application.actions.management
 
 import IconMeta
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import java.util.*
 
-class UpdateWarpIcon(private val warpRepository: WarpRepository) {
+class UpdateWarpIcon(private val warpRepository: WarpRepository,
+                     private val warpEventPublisher: WarpEventPublisher) {
     fun execute(
         editorPlayerId: UUID,
         warpId: UUID,
@@ -19,9 +21,11 @@ class UpdateWarpIcon(private val warpRepository: WarpRepository) {
             return Result.failure(Exception("Not authorized"))
         }
 
+        val oldWarp = warp.copy()
         warp.icon = materialName
         warp.iconMeta = iconMeta
         warpRepository.update(warp)
+        warpEventPublisher.warpModified(oldWarp, warp)
         return Result.success(Unit)
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpName.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpName.kt
@@ -2,10 +2,15 @@ package dev.mizarc.waystonewarps.application.actions.management
 
 import dev.mizarc.waystonewarps.application.results.UpdateWarpNameResult
 import dev.mizarc.waystonewarps.application.services.HologramService
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import java.util.*
 
-class UpdateWarpName(private val warpRepository: WarpRepository, private val hologramService: HologramService) {
+class UpdateWarpName(
+    private val warpRepository: WarpRepository, 
+    private val hologramService: HologramService,
+    private val warpEventPublisher: WarpEventPublisher
+) {
     fun execute(
         warpId: UUID,
         editorPlayerId: UUID,
@@ -26,9 +31,11 @@ class UpdateWarpName(private val warpRepository: WarpRepository, private val hol
              return UpdateWarpNameResult.NAME_ALREADY_TAKEN
         }
 
+        val oldWarp = warp.copy()
         warp.name = name
         warpRepository.update(warp)
         hologramService.updateHologram(warp)
+        warpEventPublisher.warpModified(oldWarp, warp)
         return UpdateWarpNameResult.SUCCESS
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpSkin.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpSkin.kt
@@ -3,20 +3,24 @@ package dev.mizarc.waystonewarps.application.actions.management
 import dev.mizarc.waystonewarps.application.results.UpdateWarpSkinResult
 import dev.mizarc.waystonewarps.application.services.ConfigService
 import dev.mizarc.waystonewarps.application.services.StructureBuilderService
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import java.util.UUID
 
 class UpdateWarpSkin(private val warpRepository: WarpRepository,
                      private val structureBuilderService: StructureBuilderService,
-                     private val configService: ConfigService) {
+                     private val configService: ConfigService,
+                     private val warpEventPublisher: WarpEventPublisher) {
 
     fun execute(warpId: UUID, blockName: String): UpdateWarpSkinResult {
         val warp = warpRepository.getById(warpId) ?: return UpdateWarpSkinResult.WARP_NOT_FOUND
         if (configService.getStructureBlocks(blockName).isEmpty()) return UpdateWarpSkinResult.BLOCK_NOT_VALID
         if (blockName == warp.block) return UpdateWarpSkinResult.UNCHANGED
+        val oldWarp = warp.copy()
         warp.block = blockName
         warpRepository.update(warp)
         structureBuilderService.updateStructure(warp)
+        warpEventPublisher.warpModified(oldWarp, warp)
         return UpdateWarpSkinResult.SUCCESS
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/BreakWarpBlock.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/BreakWarpBlock.kt
@@ -4,6 +4,7 @@ import dev.mizarc.waystonewarps.application.results.BreakWarpResult
 import dev.mizarc.waystonewarps.application.services.HologramService
 import dev.mizarc.waystonewarps.application.services.StructureBuilderService
 import dev.mizarc.waystonewarps.application.services.StructureParticleService
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
 import dev.mizarc.waystonewarps.domain.positioning.Position3D
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
@@ -16,7 +17,8 @@ class BreakWarpBlock(
     private val discoveryRepository: DiscoveryRepository,
     private val whitelistRepository: WhitelistRepository,
     private val structureParticleService: StructureParticleService,
-    private val hologramService: HologramService
+    private val hologramService: HologramService,
+    private val warpEventPublisher: WarpEventPublisher
 ) {
     fun execute(position: Position3D, worldId: UUID): BreakWarpResult  {
         val warp = warpRepository.getByPosition(position, worldId) ?: return BreakWarpResult.WarpNotFound
@@ -44,6 +46,7 @@ class BreakWarpBlock(
         structureBuilderService.revertStructure(warp)
         structureParticleService.removeParticles(warp)
         hologramService.removeHologram(warp)
+        warpEventPublisher.warpDeleted(warp)
         return BreakWarpResult.Success(warp)
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/CreateWarp.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/CreateWarp.kt
@@ -5,6 +5,7 @@ import dev.mizarc.waystonewarps.application.services.HologramService
 import dev.mizarc.waystonewarps.application.services.PlayerAttributeService
 import dev.mizarc.waystonewarps.application.services.StructureBuilderService
 import dev.mizarc.waystonewarps.application.services.StructureParticleService
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.discoveries.Discovery
 import dev.mizarc.waystonewarps.domain.discoveries.DiscoveryRepository
 import dev.mizarc.waystonewarps.domain.positioning.Position3D
@@ -26,7 +27,8 @@ class CreateWarp(private val warpRepository: WarpRepository,
                  private val structureBuilderService: StructureBuilderService,
                  private val discoveryRepository: DiscoveryRepository,
                  private val structureParticleService: StructureParticleService,
-                 private val hologramService: HologramService
+                 private val hologramService: HologramService,
+                 private val warpEventPublisher: WarpEventPublisher
 ) {
 
     /**
@@ -63,6 +65,7 @@ class CreateWarp(private val warpRepository: WarpRepository,
         structureBuilderService.spawnStructure(newWarp)
         structureParticleService.spawnParticles(newWarp)
         hologramService.spawnHologram(newWarp)
+        warpEventPublisher.warpCreated(newWarp)
         return CreateWarpResult.Success(newWarp)
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/MoveWarp.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/MoveWarp.kt
@@ -4,6 +4,7 @@ import dev.mizarc.waystonewarps.application.results.MoveWarpResult
 import dev.mizarc.waystonewarps.application.services.HologramService
 import dev.mizarc.waystonewarps.application.services.StructureBuilderService
 import dev.mizarc.waystonewarps.application.services.StructureParticleService
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.positioning.Position3D
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import java.util.UUID
@@ -11,7 +12,8 @@ import java.util.UUID
 class MoveWarp(private val warpRepository: WarpRepository,
                private val structureBuilderService: StructureBuilderService,
                private val structureParticleService: StructureParticleService,
-               private val hologramService: HologramService
+               private val hologramService: HologramService,
+               private val warpEventPublisher: WarpEventPublisher
 ) {
     fun execute(playerId: UUID, warpId: UUID, position: Position3D, bypassOwnership: Boolean = false): MoveWarpResult {
         val warp = warpRepository.getById(warpId) ?: return MoveWarpResult.WARP_NOT_FOUND
@@ -21,12 +23,14 @@ class MoveWarp(private val warpRepository: WarpRepository,
         }
 
         structureBuilderService.destroyStructure(warp)
+        val oldWarp = warp.copy()
         warp.position = position
         structureBuilderService.spawnStructure(warp)
         warpRepository.update(warp)
         hologramService.updateHologram(warp)
         structureParticleService.removeParticles(warp)
         structureParticleService.spawnParticles(warp)
+        warpEventPublisher.warpModified(oldWarp, warp)
         return MoveWarpResult.SUCCESS
     }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/services/WarpEventPublisher.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/services/WarpEventPublisher.kt
@@ -1,0 +1,9 @@
+package dev.mizarc.waystonewarps.application.services
+
+import dev.mizarc.waystonewarps.domain.warps.Warp
+
+interface WarpEventPublisher {
+    fun warpCreated(warp: Warp)
+    fun warpDeleted(warp: Warp)
+    fun warpModified(oldWarp: Warp, newWarp: Warp)
+}

--- a/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/Warp.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/domain/warps/Warp.kt
@@ -47,4 +47,40 @@ class Warp(val id: UUID, val playerId: UUID, val creationTime: Instant, var name
             }
         }
     }
+
+    /**
+     * Creates a deep copy of this Warp object.
+     * @return A new Warp instance with the same property values as this one.
+     */
+    fun copy(): Warp {
+        return Warp(
+            id = UUID.fromString(id.toString()),
+            playerId = UUID.fromString(playerId.toString()),
+            creationTime = Instant.ofEpochMilli(creationTime.toEpochMilli()),
+            name = name,
+            worldId = UUID.fromString(worldId.toString()),
+            position = position.copy(),
+            icon = icon,
+            iconMeta = IconMeta(
+                schemaVersion = iconMeta.schemaVersion,
+                strings = iconMeta.strings.toList(),
+                floats = iconMeta.floats.toList(),
+                flags = iconMeta.flags.toList(),
+                colorsArgb = iconMeta.colorsArgb.toList(),
+                potionTypeKey = iconMeta.potionTypeKey,
+                leatherColorRgb = iconMeta.leatherColorRgb,
+                trimPatternKey = iconMeta.trimPatternKey,
+                trimMaterialKey = iconMeta.trimMaterialKey,
+                bannerBaseColor = iconMeta.bannerBaseColor,
+                bannerPatterns = iconMeta.bannerPatterns.toList(),
+                skullTextureValue = iconMeta.skullTextureValue,
+                skullTextureSignature = iconMeta.skullTextureSignature,
+                fireworkStarColorRgb = iconMeta.fireworkStarColorRgb
+            ),
+            block = block,
+            isLocked = isLocked
+        ).also {
+            it.breakCount = this.breakCount
+        }
+    }
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/WarpEventPublisherBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/WarpEventPublisherBukkit.kt
@@ -3,10 +3,11 @@ package dev.mizarc.waystonewarps.infrastructure.services
 import dev.mizarc.waystonewarps.api.events.WarpCreateEvent
 import dev.mizarc.waystonewarps.api.events.WarpDeleteEvent
 import dev.mizarc.waystonewarps.api.events.WarpUpdateEvent
+import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.warps.Warp
 import org.bukkit.Bukkit
 
-class WarpEventPublisherBukkit {
+class WarpEventPublisherBukkit: WarpEventPublisher {
     override fun warpCreated(warp: Warp) {
         Bukkit.getPluginManager().callEvent(WarpCreateEvent(warp))
     }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/WarpEventPublisherBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/WarpEventPublisherBukkit.kt
@@ -1,0 +1,21 @@
+package dev.mizarc.waystonewarps.infrastructure.services
+
+import dev.mizarc.waystonewarps.api.events.WarpCreateEvent
+import dev.mizarc.waystonewarps.api.events.WarpDeleteEvent
+import dev.mizarc.waystonewarps.api.events.WarpUpdateEvent
+import dev.mizarc.waystonewarps.domain.warps.Warp
+import org.bukkit.Bukkit
+
+class WarpEventPublisherBukkit {
+    override fun warpCreated(warp: Warp) {
+        Bukkit.getPluginManager().callEvent(WarpCreateEvent(warp))
+    }
+
+    override fun warpDeleted(warp: Warp) {
+        Bukkit.getPluginManager().callEvent(WarpDeleteEvent(warp))
+    }
+
+    override fun warpModified(oldWarp: Warp, newWarp: Warp) {
+        Bukkit.getPluginManager().callEvent(WarpUpdateEvent(oldWarp, newWarp))
+    }
+}


### PR DESCRIPTION
As per the requested features on issue #68, a basic API has been implemented:

Events that can be accessed via API:
  - `WarpCreateEvent`: Called when a warp is created.
  - `WarpDeleteEvent`: Called when a warp is deleted.
  - `WarpUpdateEvent`: Called when a warp is updated.

Getters can be accessed via the WaystoneWarpsAPI, which provides functions:
  - getAllWarps
  - getWarpById
  - getWarpsByPlayer
  - getWarpsInWorld
  - getWarpAtLocation