### PR TITLE
Add /warpcreate command

### DIFF
--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -55,6 +55,7 @@ import dev.mizarc.waystonewarps.infrastructure.services.*
 import dev.mizarc.waystonewarps.infrastructure.services.teleportation.TeleportationServiceBukkit
 import dev.mizarc.waystonewarps.infrastructure.services.scheduling.SchedulerServiceBukkit
 import dev.mizarc.waystonewarps.interaction.commands.InvalidsCommand
+import dev.mizarc.waystonewarps.interaction.commands.WarpCreateCommand
 import dev.mizarc.waystonewarps.interaction.listeners.*
 import dev.mizarc.waystonewarps.interaction.localization.LocalizationProvider
 import net.milkbowl.vault.economy.Economy
@@ -263,6 +264,7 @@ class WaystoneWarps: JavaPlugin() {
     private fun registerCommands() {
         commandManager.registerCommand(WarpMenuCommand())
         commandManager.registerCommand(InvalidsCommand())
+        commandManager.registerCommand(WarpCreateCommand())
     }
 
     private fun registerEvents() {

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/WarpCreateCommand.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/commands/WarpCreateCommand.kt
@@ -1,0 +1,111 @@
+package dev.mizarc.waystonewarps.interaction.commands
+
+import org.bukkit.Material
+import org.bukkit.entity.Player
+
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+import co.aikar.commands.BaseCommand
+import co.aikar.commands.annotation.Default
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.CommandPermission
+import co.aikar.commands.annotation.Description
+import co.aikar.commands.annotation.Name
+
+import dev.mizarc.waystonewarps.application.actions.world.CreateWarp
+import dev.mizarc.waystonewarps.application.results.CreateWarpResult
+import dev.mizarc.waystonewarps.domain.positioning.Position3D
+import dev.mizarc.waystonewarps.interaction.localization.LocalizationProvider
+
+@CommandAlias("warpcreate")
+@CommandPermission("waystonewarps.create")
+@Description("Create a new warp with the Lodestone you're looking at")
+class WarpCreateCommand : BaseCommand(), KoinComponent {
+
+    private val createWarp: CreateWarp by inject()
+    private val localization: LocalizationProvider by inject()
+
+    /**
+     * Handles the **warpcreate** command.
+     *
+     * Usage: /warpcreate <name>
+     *
+     * @param player     the command sender
+     * @param name       the warp name
+     */
+    @Default
+    fun onWarpCreate(
+        player: Player,
+        @Name("name") name: String,
+    ) {
+        val playerId = player.uniqueId
+
+        val targetBlock = player.getTargetBlockExact(10)
+        if (targetBlock == null) {
+            player.sendMessage(
+                localization.get(playerId, "feedback.create.not_within_range")
+            )
+            return
+        }
+
+        if (targetBlock.type != Material.LODESTONE) {
+            player.sendMessage(
+                localization.get(playerId, "feedback.create.not_lodestone")
+            )
+            return
+        }
+
+        if (targetBlock.getRelative(org.bukkit.block.BlockFace.DOWN).type != Material.SMOOTH_STONE) {
+            player.sendMessage(
+                localization.get(playerId, "feedback.create.not_smooth_stone")
+            )
+            return
+        }
+
+        val blockLoc = targetBlock.location
+        val position = Position3D(
+            x = blockLoc.x.toInt(),
+            y = blockLoc.y.toInt(),
+            z = blockLoc.z.toInt(),
+        )
+        val worldId = blockLoc.world?.uid ?: run {
+            player.sendMessage(
+                localization.get(playerId, "feedback.create.world_not_found")
+            )
+            return
+        }
+
+        val result = createWarp.execute(
+            playerId = playerId,
+            name = name,
+            position3D = position,
+            worldId = worldId,
+            baseBlock = "LODESTONE"
+        )
+
+        when (result) {
+            is CreateWarpResult.Success -> {
+                player.sendMessage(
+                    localization.get(playerId, "feedback.create.success")
+                )
+            }
+            CreateWarpResult.LimitExceeded -> {
+                player.sendMessage(
+                    localization.get(playerId, "condition.naming.limit")
+                )
+            }
+            CreateWarpResult.NameCannotBeBlank -> {
+                player.sendMessage(
+                    localization.get(playerId,"condition.naming.blank")
+                )
+            }
+            CreateWarpResult.NameAlreadyExists -> {
+                player.sendMessage(
+                    localization.get(playerId,"condition.naming.existing")
+                )
+            }
+        }
+
+    }
+}

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -32,6 +32,13 @@ feedback.move_tool.not_owner=You don't own this warp!
 feedback.waystone.skin_updated=Updated waystone skin!
 feedback.waystone.invalid=Waystone is invalid
 
+# Waystone Creation Messages
+feedback.create.world_not_found=Could not find the world you're at
+feedback.create.not_within_range=There is no block with range, make sure you're looking at a Lodestone
+feedback.create.not_lodestone=This block is not a Lodestone
+feedback.create.not_smooth_stone=There is no Smooth Stone block below this Lodestone
+feedback.create.success=Lodestone created with success!
+
 # Waystone Destruction Messages
 feedback.waystone.break_progress=Break {0} more times in 10 seconds to destroy this waystone
 feedback.waystone.destroyed=Waystone ''{0}'' has been destroyed
@@ -132,7 +139,7 @@ menu.warp_icon.info_item.lore=Don't worry, you'll get the item back
 menu.warp_skins.title=Available Skins
 menu.warp_skins.item.tooltip.name=Blocks here are only for display
 menu.warp_skins.item.tooltip.line1=If you own the block, hold the item in your hand and
-menu.warp_skins.item.tooltip.line2=right click the base of the waystone to change the skin.
+menu.warp_skins.item.tooltip.line2=rightclick the base of the waystone to change the skin.
 
 # Warp Menu
 menu.warp.title=Warps


### PR DESCRIPTION
Providing a way for users to create warps with commands is useful for users that prefer the command interface or cannot use UI (as in #82).

Usage is `/warpcreate <name>` while looking at a valid waystone structure (Lodestone on top of a Smooth Stone) and it requires the same permission to create a warp using GUI.

5 new localization messages were added to accommodate the new command responses.

Closes #88. I'm open to further change requests.