### PR TITLE
Update Waystone skin tooltip message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Towny support, which allows for free travel between two of the same town.
 - Simplified Chinese (zh_cn) localization.
 
+### Changed
+- Waystone skin menu tooltip now provides clearer information on how to use the blocks to apply the skins.
+
 ### Fixed
 - Teleport particles and sound not appearing when teleportation is instant.
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/localization/LocalizationKeys.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/localization/LocalizationKeys.kt
@@ -69,15 +69,15 @@ object LocalizationKeys {
     const val MENU_COMMON_ITEM_NEXT_NAME = "menu.common.item.next.name"
     const val MENU_COMMON_ITEM_PAGE_NAME = "menu.common.item.page.name"
     const val MENU_COMMON_ITEM_PREV_NAME = "menu.common.item.prev.name"
-    
+
     // Player Search Menu
     const val MENU_PLAYER_SEARCH_TITLE = "menu.player_search.title"
-    
+
     // Warp Icon Menu
     const val MENU_WARP_ICON_TITLE = "menu.warp_icon.title"
     const val MENU_WARP_ICON_INFO_ITEM_NAME = "menu.warp_icon.info_item.name"
     const val MENU_WARP_ICON_INFO_ITEM_LORE = "menu.warp_icon.info_item.lore"
-    
+
     // Warp Management Menu
     const val MENU_WARP_MANAGEMENT_TITLE = "menu.warp_management.title"
     const val MENU_WARP_MANAGEMENT_ACCESS_NAME = "menu.warp_management.access.name"
@@ -103,7 +103,7 @@ object LocalizationKeys {
     // Warp Naming Menu
     const val MENU_WARP_NAMING_TITLE = "menu.warp_naming.title"
     const val MENU_WARP_NAMING_ITEM_WARP_LORE = "menu.warp_naming.item.warp.lore"
-    
+
     // Warp Player Menu
     const val MENU_WARP_PLAYER_TITLE = "menu.warp_player.title"
     const val MENU_WARP_PLAYER_ITEM_DISCOVERED = "menu.warp_player.item.discovered.name"
@@ -119,10 +119,10 @@ object LocalizationKeys {
     const val MENU_WARP_PLAYER_ITEM_PLAYER_LORE_NO_PERMISSION = "menu.warp_player.item.player.lore.no_permission"
     const val MENU_WARP_PLAYER_ITEM_PLAYER_LORE_TOGGLE_WHITELIST = "menu.warp_player.item.player.lore.toggle_whitelist"
     const val MENU_WARP_PLAYER_ITEM_PLAYER_LORE_REVOKE_ACCESS = "menu.warp_player.item.player.lore.revoke_access"
-    
+
     // Warp Renaming Menu
     const val MENU_WARP_RENAMING_TITLE = "menu.warp_renaming.title"
-    
+
     // Warp Options Menu
     const val MENU_WARP_OPTIONS_TITLE = "menu.warp_options.title"
     const val MENU_WARP_OPTIONS_ITEM_LOCATE_NAME = "menu.warp_options.item.locate.name"
@@ -138,10 +138,10 @@ object LocalizationKeys {
     const val MENU_WARP_OPTIONS_ITEM_CANNOT_DELETE_NAME = "menu.warp_options.item.cannot_delete.name"
     const val MENU_WARP_OPTIONS_ITEM_CANNOT_DELETE_LORE = "menu.warp_options.item.cannot_delete.lore"
     const val MENU_WARP_OPTIONS_CONFIRM_DELETE = "menu.warp_options.confirm.delete"
-    
+
     // Warp Search Menu
     const val MENU_WARP_SEARCH_TITLE = "menu.warp_search.title"
-    
+
     // Warp Menu
     const val MENU_WARP_TITLE = "menu.warp.title"
     const val MENU_WARP_ITEM_VIEW_MODE_DISCOVERED_NAME = "menu.warp.item.view_mode.discovered.name"
@@ -162,7 +162,7 @@ object LocalizationKeys {
     const val MENU_WARP_ITEM_FILTER_USABLE_LORE = "menu.warp.item.filter.usable.lore"
     const val MENU_WARP_ITEM_FILTER_UNUSABLE_NAME = "menu.warp.item.filter.unusable.name"
     const val MENU_WARP_ITEM_FILTER_UNUSABLE_LORE = "menu.warp.item.filter.unusable.lore"
-    
+
     // Warp Groups Browse Menu
     const val MENU_WARP_GROUPS_TITLE = "menu.warp_groups.title"
     const val MENU_WARP_GROUPS_ITEM_WARP_COUNT = "menu.warp_groups.item.warp_count"
@@ -199,13 +199,15 @@ object LocalizationKeys {
     // Warp Title (group-filtered)
     const val MENU_WARP_TITLE_GROUPED = "menu.warp.title.grouped"
 
-    
+
     // Warp Skins Menu
     const val MENU_WARP_SKINS_TITLE = "menu.warp_skins.title"
     const val MENU_WARP_SKINS_ITEM_TOOLTIP_NAME = "menu.warp_skins.item.tooltip.name"
     const val MENU_WARP_SKINS_ITEM_TOOLTIP_LINE_1 = "menu.warp_skins.item.tooltip.line1"
     const val MENU_WARP_SKINS_ITEM_TOOLTIP_LINE_2 = "menu.warp_skins.item.tooltip.line2"
-    
+    const val MENU_WARP_SKINS_ITEM_TOOLTIP_LINE_3 = "menu.warp_skins.item.tooltip.line3"
+    const val MENU_WARP_SKINS_ITEM_TOOLTIP_LINE_4 = "menu.warp_skins.item.tooltip.line4"
+
     // Confirmation Menu
     const val MENU_CONFIRMATION_ITEM_YES_NAME = "menu.confirmation.item.yes.name"
     const val MENU_CONFIRMATION_ITEM_YES_LORE = "menu.confirmation.item.yes.lore"
@@ -223,6 +225,6 @@ object LocalizationKeys {
     const val COMMAND_INVALIDS_REMOVE_ERROR = "command.invalids.remove.error"
     const val COMMAND_INVALIDS_REMOVE_INVALID_WORLD = "command.invalids.remove.invalid_world"
     const val COMMAND_INVALIDS_NO_INVALID_WARPS = "command.invalids.no_invalid_warps"
-    
+
 
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpSkinsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpSkinsMenu.kt
@@ -21,7 +21,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class WarpSkinsMenu(
-    private val player: Player, 
+    private val player: Player,
     private val menuNavigator: MenuNavigator,
     private val localizationProvider: LocalizationProvider
 ): Menu, KoinComponent {
@@ -56,6 +56,8 @@ class WarpSkinsMenu(
             .name(localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_SKINS_ITEM_TOOLTIP_NAME), PrimaryColourPalette.INFO.color!!)
             .lore(localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_SKINS_ITEM_TOOLTIP_LINE_1))
             .lore(localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_SKINS_ITEM_TOOLTIP_LINE_2))
+            .lore(localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_SKINS_ITEM_TOOLTIP_LINE_3))
+            .lore(localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_SKINS_ITEM_TOOLTIP_LINE_4))
         val tooltipGuiItem = GuiItem(tooltipItem) { guiEvent -> guiEvent.isCancelled = true }
         navigationPane.addItem(tooltipGuiItem, 0, 2)
 

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -144,10 +144,10 @@ menu.warp_icon.info_item.lore=Don't worry, you'll get the item back
 # Warp Skins Menu
 menu.warp_skins.title=Available Skins
 menu.warp_skins.item.tooltip.name=Appearance Preview Only
-menu.warp_skins.item.tooltip.line1=To apply a skin, hold one of these blocks in your hand and
-menu.warp_skins.item.tooltip.line2=right-click the top edge of the base of an active Waystone.
-menu.warp_skins.item.tooltip.line3=You can also use these blocks as the base when
-menu.warp_skins.item.tooltip.line4=building a new Waystone to instantly apply it.
+menu.warp_skins.item.tooltip.line1=To apply a skin, hold the matching block and
+menu.warp_skins.item.tooltip.line2=right-click the top edge of a Waystone's base.
+menu.warp_skins.item.tooltip.line3=Alternatively, use the block as the base when
+menu.warp_skins.item.tooltip.line4=building a new Waystone to apply it by default.
 
 # Warp Menu
 menu.warp.title=Warps

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -143,9 +143,11 @@ menu.warp_icon.info_item.lore=Don't worry, you'll get the item back
 
 # Warp Skins Menu
 menu.warp_skins.title=Available Skins
-menu.warp_skins.item.tooltip.name=Blocks here are only for display
-menu.warp_skins.item.tooltip.line1=If you own the block, hold the item in your hand and
-menu.warp_skins.item.tooltip.line2=rightclick the base of the waystone to change the skin.
+menu.warp_skins.item.tooltip.name=Appearance Preview Only
+menu.warp_skins.item.tooltip.line1=To apply a skin, hold one of these blocks in your hand and
+menu.warp_skins.item.tooltip.line2=right-click the top edge of the base of an active Waystone.
+menu.warp_skins.item.tooltip.line3=You can also use these blocks as the base when
+menu.warp_skins.item.tooltip.line4=building a new Waystone to instantly apply it.
 
 # Warp Menu
 menu.warp.title=Warps

--- a/src/main/resources/lang/defaults/zh_cn.properties
+++ b/src/main/resources/lang/defaults/zh_cn.properties
@@ -131,8 +131,10 @@ menu.warp_icon.info_item.lore=别担心，物品会退还给你
 # Warp Skins Menu
 menu.warp_skins.title=可用外观
 menu.warp_skins.item.tooltip.name=此处的方块仅作展示
-menu.warp_skins.item.tooltip.line1=如果你拥有该方块，请手持物品
-menu.warp_skins.item.tooltip.line2=右键点击传送石基座以更改外观。
+menu.warp_skins.item.tooltip.line1=若要应用皮肤，请手持此类方块并
+menu.warp_skins.item.tooltip.line2=右键点击现有传送石碑底座的上边缘。
+menu.warp_skins.item.tooltip.line3=你也可以在建造新传送石碑时将这些方块
+menu.warp_skins.item.tooltip.line4=用作底座，以直接应用该外观。
 
 # Warp Menu
 menu.warp.title=传送点


### PR DESCRIPTION
## 📖 Summary
The current tooltip isn't really intuitive enough, providing little information on where exactly to click on the base of the Waystone, as well as not informing people they can build the Waystone with the skin applied by default. The tooltip has now been reworded with extra lines added.

## 🔗 Linked Issues
Resolves #96

## ⚠️ Breaking Changes
<!-- Does this PR introduce changes that require users to update their own code, configs, or saved data? (e.g., API changes, removed features, or altered file structures). If none, please state "None" -->
None

## 📸 Screenshots/Video (if applicable)
<!-- For UI changes or new visual features, please include a screenshot or screen recording. This significantly speeds up the review process. -->
<img width="898" height="358" alt="image" src="https://github.com/user-attachments/assets/a4db9def-c091-4e98-99dc-bc750f3a017e" />


## 🏁 Quality Check
- [x] I’ve verified my individual commits are meaningful (no "fix," "test" spam).
- [x] My code follows the project's style guidelines.
- [x] Changes have been tested and verified.
- [x] Updated README/Wiki/Javadocs if applicable.

---
*By submitting this PR, I agree to license my contributions under the project's current license.*