### PR TITLE
Fix item deletion when shift clicking into branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 - Teleport particles and sound not appearing when teleportation is instant.
+- Shift clicking items into menus deletes items.
 
 ## [1.0.0]
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/admin/WarpGroupCreateMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/admin/WarpGroupCreateMenu.kt
@@ -15,6 +15,7 @@ import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
 import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -32,6 +33,8 @@ class WarpGroupCreateMenu(
     override fun open() {
         val gui = AnvilGui(localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_GROUP_CREATE_TITLE))
         gui.setOnTopClick { it.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
         gui.setOnNameInputChanged { newName ->
             if (!isConfirming) groupName = newName else isConfirming = false
         }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/admin/WarpGroupManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/admin/WarpGroupManagementMenu.kt
@@ -20,6 +20,7 @@ import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
 import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -39,6 +40,8 @@ class WarpGroupManagementMenu(
         val gui =
             ChestGui(6, localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_GROUP_MANAGEMENT_TITLE))
         gui.setOnTopClick { it.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Border
         val outlinePane = OutlinePane(9, 5)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/admin/WarpGroupRenameMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/admin/WarpGroupRenameMenu.kt
@@ -15,6 +15,7 @@ import dev.mizarc.waystonewarps.interaction.messaging.PrimaryColourPalette
 import dev.mizarc.waystonewarps.interaction.utils.name
 import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -33,6 +34,8 @@ class WarpGroupRenameMenu(
     override fun open() {
         val gui = AnvilGui(localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_GROUP_RENAME_TITLE))
         gui.setOnTopClick { it.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
         gui.setOnNameInputChanged { input ->
             if (!isConfirming) newName = input else isConfirming = false
         }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpGroupPickerMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpGroupPickerMenu.kt
@@ -18,6 +18,7 @@ import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
 import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -36,6 +37,8 @@ class WarpGroupPickerMenu(
     override fun open() {
         val gui = ChestGui(4, localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_GROUP_PICKER_TITLE))
         gui.setOnTopClick { it.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         val controlsPane = StaticPane(6, 1)
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpManagementMenu.kt
@@ -25,6 +25,7 @@ import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -41,6 +42,8 @@ class WarpManagementMenu(private val player: Player, private val menuNavigator: 
         val title = localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_MANAGEMENT_TITLE, warp.name)
         val gui = ChestGui(1, title)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         val pane = StaticPane(9, 1)
         gui.addPane(Slot.fromXY(0, 0), pane)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpNamingMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpNamingMenu.kt
@@ -21,6 +21,7 @@ import org.bukkit.Material
 import org.bukkit.Sound
 import org.bukkit.SoundCategory
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -39,6 +40,8 @@ class WarpNamingMenu(
         val title = localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_NAMING_TITLE)
         val gui = AnvilGui(title)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
         gui.setOnNameInputChanged { newName ->
             if (!isConfirming) {
                 name = newName

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpRenamingMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/management/WarpRenamingMenu.kt
@@ -17,12 +17,13 @@ import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
 import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class WarpRenamingMenu(
-    private val player: Player, 
+    private val player: Player,
     private val menuNavigator: MenuNavigator,
     private val warp: Warp,
     private val localizationProvider: LocalizationProvider
@@ -44,6 +45,8 @@ class WarpRenamingMenu(
         // Create renaming menu
         val gui = AnvilGui(localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_RENAMING_TITLE))
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
         gui.setOnNameInputChanged { newName ->
             if (!isConfirming) {
                 name = newName
@@ -88,7 +91,7 @@ class WarpRenamingMenu(
                 UpdateWarpNameResult.WARP_NOT_FOUND -> {
                     val paperItem = ItemStack(Material.PAPER)
                         .name(localizationProvider.get(
-                            player.uniqueId, 
+                            player.uniqueId,
                             LocalizationKeys.CONDITION_NAMING_NOT_FOUND
                         ), PrimaryColourPalette.FAILED.color!!)
                     val guiPaperItem = GuiItem(paperItem)
@@ -100,7 +103,7 @@ class WarpRenamingMenu(
                 UpdateWarpNameResult.NAME_ALREADY_TAKEN -> {
                     val paperItem = ItemStack(Material.PAPER)
                         .name(localizationProvider.get(
-                            player.uniqueId, 
+                            player.uniqueId,
                             LocalizationKeys.CONDITION_NAMING_EXISTING,
                             name
                         ), PrimaryColourPalette.FAILED.color!!)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpGroupBrowseMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpGroupBrowseMenu.kt
@@ -18,6 +18,7 @@ import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
 import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -35,6 +36,8 @@ class WarpGroupBrowseMenu(
     override fun open() {
         val gui = ChestGui(6, localizationProvider.get(player.uniqueId, LocalizationKeys.MENU_WARP_GROUPS_TITLE))
         gui.setOnTopClick { it.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Border
         val outlinePane = OutlinePane(9, 5)

--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -33,6 +33,7 @@ import dev.mizarc.waystonewarps.interaction.utils.lore
 import dev.mizarc.waystonewarps.interaction.utils.name
 import me.xdrop.fuzzywuzzy.FuzzySearch
 import net.kyori.adventure.text.Component
+import org.bukkit.event.inventory.ClickType
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.UUID
@@ -66,6 +67,8 @@ class WarpMenu(
         }
         val gui = ChestGui(6, title)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add controls pane
         addControlsSection(gui)


### PR DESCRIPTION
### 📖 Summary
<!-- Summarize the intent of this branch. Provide a high-level overview of the changes included here. -->
When the user shift clicks an item in their inventory, the item ends up on the menu. The item cannot be taken out of the menu again, causing the item to be deleted.

### 🔗 Linked Issues
<!-- Use keywords like 'Resolves #123' or 'Fixes #123' to link and automatically close the relevant issue. If no issue exists, please explain the necessity of this change. -->
Fixes #104 

### ⚠️ Breaking Changes
<!-- Does this PR introduce changes that require users to update their own code, configs, or saved data? (e.g., API changes, removed features, or altered file structures). If none, please state "None" -->
None

### 📸 Screenshots/Video (if applicable)
<!-- For UI changes or new visual features, please include a screenshot or screen recording. -->
None

### 🏁 Quality Check
- [x] I’ve verified my individual commits are meaningful (no "fix," "test" spam).
- [x] My code follows the project's style guidelines.
- [x] Changes have been tested and verified.
- [x] Updated README/Wiki/Docs if applicable.

---
*By submitting this PR, I agree to license my contributions under the project's current license.*
