### PR TITLE
Downgrade Paper API to 1.21.4 for backwards compat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ repositories {
 dependencies {
     testImplementation(kotlin("test"))
     compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
-    compileOnly("io.papermc.paper:paper-api:26.1.2.build.53-stable")
+    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.3.0")
     compileOnly("io.insert-koin:koin-core-jvm:4.1.1")
     implementation("co.aikar:idb-core:1.0.0-SNAPSHOT")
@@ -68,18 +68,18 @@ dependencies {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(25))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(21)
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_25)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release.set(25)
+    options.release.set(21)
 }
 
 tasks.test {


### PR DESCRIPTION
### 📖 Summary
<!-- Summarize the intent of this branch. Provide a high-level overview of the changes included here. -->
There's no need for us to use the latest API to get the current set of features to work. This maintains better backwards compatibility down to 1.21.4.

### 🔗 Linked Issues
<!-- Use keywords like 'Resolves #123' or 'Fixes #123' to link and automatically close the relevant issue. If no issue exists, please explain the necessity of this change. -->
None

### ⚠️ Breaking Changes
<!-- Does this PR introduce changes that require users to update their own code, configs, or saved data? (e.g., API changes, removed features, or altered file structures). If none, please state "None" -->
None

### 📸 Screenshots/Video (if applicable)
<!-- For UI changes or new visual features, please include a screenshot or screen recording. -->
None

### 🏁 Quality Check
- [x] I’ve verified my individual commits are meaningful (no "fix," "test" spam).
- [x] My code follows the project's style guidelines.
- [x] Changes have been tested and verified.
- [x] Updated README/Wiki/Docs if applicable.

---
*By submitting this PR, I agree to license my contributions under the project's current license.*
