### PR TITLE
fix: warp menu page offset

### DIFF
--- a/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/interaction/menus/use/WarpMenu.kt
@@ -508,7 +508,7 @@ class WarpMenu(
 
             // Check if the current page is full (21 players)
             if (playerCounter >= 21) {
-                playerPane.addPage(Slot.fromXY(1, 2), currentPagePane)
+                playerPane.addPage(Slot.fromXY(0, 0), currentPagePane)
                 currentPagePane = OutlinePane(7, 3)
                 playerCounter = 0
             }


### PR DESCRIPTION
### 📖 Summary

This PR fixes the warp menu layout breaking when the visible warp list reaches a full page of 21 entries.

When a warp page becomes full, it was added to the `PaginatedPane` with `Slot.fromXY(1, 2)`, while non-full pages are added with `Slot.fromXY(0, 0)`.

Since the `PaginatedPane` itself is already placed in the GUI with an offset, full pages were receiving an extra offset. This caused warp icons to shift and disappear from the expected 7x3 grid.

This change makes full pages use the same origin as non-full pages.

### 🔗 Linked Issues

Fixes #131

### ⚠️ Breaking Changes

None

### 📸 Screenshots/Video (if applicable)

See the screenshot attached in #131.

With this bug fixed:
<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/3f17f634-7fd7-41ac-94d6-53d967299e5e" />


### 🏁 Quality Check

* [x] I’ve verified my individual commits are meaningful (no "fix," "test" spam).
* [x] My code follows the project's style guidelines.
* [x] Changes have been tested and verified.
* [x] Updated README/Wiki/Docs if applicable.

---

*By submitting this PR, I agree to license my contributions under the project's current license.*