### PR TITLE
feat: Add config option to allow non unique warp names

### DIFF
--- a/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/WaystoneWarps.kt
@@ -295,11 +295,11 @@ class WaystoneWarps: JavaPlugin() {
 
         val actions = module {
             single { CreateWarp(warpRepository, playerAttributeService, structureBuilderService,
-                discoveryRepository, structureParticleService, hologramService, warpEventPublisher) }
+                discoveryRepository, structureParticleService, hologramService, warpEventPublisher, configService) }
             single { GetWarpPlayerAccess(discoveryRepository) }
             single { GetPlayerWarpAccess(discoveryRepository, warpRepository) }
             single { UpdateWarpIcon(warpRepository, warpEventPublisher) }
-            single { UpdateWarpName(warpRepository, hologramService, warpEventPublisher) }
+            single { UpdateWarpName(warpRepository, hologramService, warpEventPublisher, configService) }
             single { GetWarpAtPosition(warpRepository) }
             single { BreakWarpBlock(warpRepository, structureBuilderService,
                 discoveryRepository, whitelistRepository, structureParticleService, hologramService, warpEventPublisher) }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpName.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/management/UpdateWarpName.kt
@@ -1,15 +1,17 @@
 package dev.mizarc.waystonewarps.application.actions.management
 
 import dev.mizarc.waystonewarps.application.results.UpdateWarpNameResult
+import dev.mizarc.waystonewarps.application.services.ConfigService
 import dev.mizarc.waystonewarps.application.services.HologramService
 import dev.mizarc.waystonewarps.application.services.WarpEventPublisher
 import dev.mizarc.waystonewarps.domain.warps.WarpRepository
 import java.util.*
 
 class UpdateWarpName(
-    private val warpRepository: WarpRepository, 
+    private val warpRepository: WarpRepository,
     private val hologramService: HologramService,
-    private val warpEventPublisher: WarpEventPublisher
+    private val warpEventPublisher: WarpEventPublisher,
+    private val configService: ConfigService
 ) {
     fun execute(
         warpId: UUID,
@@ -27,7 +29,7 @@ class UpdateWarpName(
         }
 
         // Use the warp owner's ID to check for duplicate names
-        if (warpRepository.getByName(warp.playerId, name) != null) {
+        if (!configService.warpNameNonUniqueAllowed() && warpRepository.getByName(warp.playerId, name) != null) {
              return UpdateWarpNameResult.NAME_ALREADY_TAKEN
         }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/CreateWarp.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/actions/world/CreateWarp.kt
@@ -1,6 +1,7 @@
 package dev.mizarc.waystonewarps.application.actions.world
 
 import dev.mizarc.waystonewarps.application.results.CreateWarpResult
+import dev.mizarc.waystonewarps.application.services.ConfigService
 import dev.mizarc.waystonewarps.application.services.HologramService
 import dev.mizarc.waystonewarps.application.services.PlayerAttributeService
 import dev.mizarc.waystonewarps.application.services.StructureBuilderService
@@ -27,7 +28,8 @@ class CreateWarp(private val warpRepository: WarpRepository,
                  private val discoveryRepository: DiscoveryRepository,
                  private val structureParticleService: StructureParticleService,
                  private val hologramService: HologramService,
-                 private val warpEventPublisher: WarpEventPublisher
+                 private val warpEventPublisher: WarpEventPublisher,
+                 private val configService: ConfigService
 ) {
 
     /**
@@ -55,8 +57,7 @@ class CreateWarp(private val warpRepository: WarpRepository,
             return CreateWarpResult.NameCannotBeBlank
         }
 
-        val existingWarp = warpRepository.getByName(playerId, name)
-        if (existingWarp != null) {
+        if (!configService.warpNameNonUniqueAllowed() && warpRepository.getByName(playerId, name) != null) {
             return CreateWarpResult.NameAlreadyExists
         }
 

--- a/src/main/kotlin/dev/mizarc/waystonewarps/application/services/ConfigService.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/application/services/ConfigService.kt
@@ -25,4 +25,5 @@ interface ConfigService {
     fun worldNameEnabled(): Boolean
     fun bossBarEnabled(): Boolean
     fun warpGroupsEnabled(): Boolean
+    fun warpNameNonUniqueAllowed(): Boolean
 }

--- a/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/waystonewarps/infrastructure/services/ConfigServiceBukkit.kt
@@ -96,4 +96,8 @@ class ConfigServiceBukkit(private val configFile: FileConfiguration) : ConfigSer
     override fun warpGroupsEnabled(): Boolean {
         return configFile.getBoolean("warp_groups_enabled", false)
     }
+
+    override fun warpNameNonUniqueAllowed(): Boolean {
+        return configFile.getBoolean("warp_name_allow_non_unique", false)
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,6 +69,9 @@ boss_bar_enabled: false
 # If the warp group system should be enabled, allowing you to tag warps to appear in a given category.
 warp_groups_enabled: false
 
+# If enabled, allows multiple warps to have the same name
+warp_name_allow_non_unique: false
+
 # The blocks that can be used to transform the waystone appearance. This
 # contains all the required blocks that make up the waystone that must be in the
 # following order:


### PR DESCRIPTION
### 📖 Summary
Currently you are not allowed to create a warp if there already is a warp with that name.
This is fine for single world servers, but on multi-world servers you quickly run into the problem that you have to add suffixes to every warp name.
I could not find any use of warps name besides the duplicate name check and during my testing didn't experience any issues.

### 🔗 Linked Issues
n/a

### ⚠️ Breaking Changes
Don't think so

### 📸 Screenshots/Video (if applicable)
n/a

### 🏁 Quality Check
- [x] I’ve verified my individual commits are meaningful (no "fix," "test" spam).
- [x] My code follows the project's style guidelines.
- [x] Changes have been tested and verified.
- [x] Updated README/Wiki/Docs if applicable.

---
*By submitting this PR, I agree to license my contributions under the project's current license.*
